### PR TITLE
fix cstdint related build error

### DIFF
--- a/src/base/utils.h
+++ b/src/base/utils.h
@@ -3,6 +3,7 @@
 
 #include <string>
 #include <vector>
+#include <cstdint>
 
 namespace Ramulator {
 


### PR DESCRIPTION
When make with a newer g++ version (g++-13) and clang++ version (clang++-16), there will be a build error, error output as follows:

```
[ 93%] Building CXX object src/dram_controller/CMakeFiles/ramulator-controller.dir/impl/plugin/rrs.cpp.o
In file included from /home/tongxian/projects/ramulator2-addSeDRAM/src/base/utils.cpp:1:
/home/tongxian/projects/ramulator2-addSeDRAM/src/base/utils.h:37:1: error: ‘uint64_t’ does not name a type
   37 | uint64_t JEDEC_rounding(float t_ns, int tCK_ps);
      | ^~~~~~~~
/home/tongxian/projects/ramulator2-addSeDRAM/src/base/utils.h:6:1: note: ‘uint64_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
    5 | #include <vector>
  +++ |+#include <cstdint>
    6 | //#include <cstdint>
/home/tongxian/projects/ramulator2-addSeDRAM/src/base/utils.h:47:1: error: ‘uint64_t’ does not name a type
   47 | uint64_t JEDEC_rounding_DDR5(float t_ns, int tCK_ps);
      | ^~~~~~~~
/home/tongxian/projects/ramulator2-addSeDRAM/src/base/utils.h:47:1: note: ‘uint64_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
/home/tongxian/projects/ramulator2-addSeDRAM/src/base/utils.cpp:32:1: error: ‘uint64_t’ does not name a type
   32 | uint64_t JEDEC_rounding(float t_ns, int tCK_ps) {
      | ^~~~~~~~
/home/tongxian/projects/ramulator2-addSeDRAM/src/base/utils.cpp:2:1: note: ‘uint64_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
    1 | #include "base/utils.h"
  +++ |+#include <cstdint>
    2 | 
/home/tongxian/projects/ramulator2-addSeDRAM/src/base/utils.cpp:41:1: error: ‘uint64_t’ does not name a type
   41 | uint64_t JEDEC_rounding_DDR5(float t_ns, int tCK_ps) {
```

Because actually there is only one type of error (`did you forget to ‘#include <cstdint>’`), I only paste part of the error output.

As compiler suggests, I add `#include <cstdint>` to the file `src/base/utils.cpp`, then the error is fixed and I can successfully build it.

After I added this include, I build it with g++-12, it is compatible and build successfully.