### PR TITLE
add cstdint header to utils.h

### DIFF
--- a/src/base/utils.h
+++ b/src/base/utils.h
@@ -3,6 +3,7 @@
 
 #include <string>
 #include <vector>
+#include <cstdint>
 
 namespace Ramulator {
 


### PR DESCRIPTION
When building ramulator2 on Debian/trixie, which uses gcc version 13.2.0, the following error message shows:

```
[ 39%] Building CXX object src/base/CMakeFiles/ramulator-base.dir/stats.cpp.o
In file included from /tmp/ramulator2/src/frontend/impl/processor/simpleO3/simpleO3.cpp:3:
/tmp/ramulator2/src/base/utils.h:36:1: error: ‘uint64_t’ does not name a type
   36 | uint64_t JEDEC_rounding(float t_ns, int tCK_ps);
      | ^~~~~~~~
/tmp/ramulator2/src/base/utils.h:5:1: note: ‘uint64_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
    4 | #include <string>
  +++ |+#include <cstdint>
    5 | #include <vector>
/tmp/ramulator2/src/base/utils.h:46:1: error: ‘uint64_t’ does not name a type
   46 | uint64_t JEDEC_rounding_DDR5(float t_ns, int tCK_ps);
      | ^~~~~~~~
/tmp/ramulator2/src/base/utils.h:46:1: note: ‘uint64_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
In file included from /tmp/ramulator2/src/base/utils.cpp:1:
/tmp/ramulator2/src/base/utils.h:36:1: error: ‘uint64_t’ does not name a type
   36 | uint64_t JEDEC_rounding(float t_ns, int tCK_ps);
      | ^~~~~~~~
/tmp/ramulator2/src/base/utils.h:6:1: note: ‘uint64_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
    5 | #include <vector>
  +++ |+#include <cstdint>
    6 | 
/tmp/ramulator2/src/base/utils.h:46:1: error: ‘uint64_t’ does not name a type
   46 | uint64_t JEDEC_rounding_DDR5(float t_ns, int tCK_ps);
      | ^~~~~~~~
/tmp/ramulator2/src/base/utils.h:46:1: note: ‘uint64_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
[ 40%] Building CXX object _deps/yaml-cpp-build/CMakeFiles/yaml-cpp.dir/src/convert.cpp.o
make[2]: *** [src/base/CMakeFiles/ramulator-base.dir/build.make:104: src/base/CMakeFiles/ramulator-base.dir/utils.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
```

It can be fixed by adding `#include <cstdint>` to the `utils.h` file, which works. 

I noticed #8 did the same thing as me, but it has been closed; the problem still needs to be fixed.