### PR TITLE
Fix CMake issues for using Ramulator as a dependency in other projects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,21 +1,27 @@
 cmake_minimum_required(VERSION 3.14)
 
 project(
-  Ramulator
+  Ramulator2
   VERSION 2.0
   LANGUAGES CXX
 )
 
-#### Prompt the build type ####
+# Configure build type ========================================================
+
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "Release" CACHE STRING "" FORCE)
 endif()
-message("Configuring ${CMAKE_PROJECT_NAME} ${CMAKE_PROJECT_Version}...")
+
 message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")
-set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -DRAMULATOR_DEBUG")
+
+set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Dramulator2_DEBUG")
 # set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE}")
+
+set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
+
+# Project settings ============================================================
+
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
-###############################
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON CACHE INTERNAL "")
 
@@ -23,22 +29,24 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-#### External libraries ####
+# External libraries ==========================================================
+
 include(FetchContent)
-set(FETCHCONTENT_UPDATES_DISCONNECTED ON CACHE BOOL "Skip updating the external dependencies after populating them for the first time")
+
+set(FETCHCONTENT_UPDATES_DISCONNECTED ON CACHE BOOL
+    "Skip update of external dependencies after first build."
+)
 
 message("Configuring yaml-cpp...")
-option(YAML_CPP_BUILD_CONTRIB "Enable yaml-cpp contrib in library" OFF)
-option(YAML_CPP_BUILD_TOOLS "Enable parse tools" OFF)
-option(YAML_BUILD_SHARED_LIBS "Build yaml-cpp as a shared library" OFF)
+set(YAML_CPP_BUILD_CONTRIB OFF)
+set(YAML_CPP_BUILD_TOOLS OFF)
+set(YAML_BUILD_SHARED_LIBS OFF)
 FetchContent_Declare(
   yaml-cpp
   GIT_REPOSITORY https://github.com/jbeder/yaml-cpp.git
   GIT_TAG        yaml-cpp-0.7.0
-  SOURCE_DIR     ${PROJECT_SOURCE_DIR}/ext/yaml-cpp
 )
 FetchContent_MakeAvailable(yaml-cpp)
-include_directories(${yaml-cpp_SOURCE_DIR}/include)
 message("Done configuring yaml-cpp.")
 
 message("Configuring spdlog...")
@@ -46,48 +54,73 @@ FetchContent_Declare(
   spdlog
   GIT_REPOSITORY https://github.com/gabime/spdlog.git
   GIT_TAG        v1.11.0
-  SOURCE_DIR     ${PROJECT_SOURCE_DIR}/ext/spdlog
 )
 FetchContent_MakeAvailable(spdlog)
-include_directories(${spdlog_SOURCE_DIR}/include)
 message("Done configuring spdlog.")
 
 message("Configuring argparse...")
 FetchContent_Declare(
     argparse
     GIT_REPOSITORY https://github.com/p-ranav/argparse.git
-    GIT_TAG        v2.9
-    SOURCE_DIR     ${PROJECT_SOURCE_DIR}/ext/argparse
+    GIT_TAG        v3.0
 )
 FetchContent_MakeAvailable(argparse)
-include_directories(${argparse_SOURCE_DIR}/include)
 message("Done configuring argparse.")
-##################################
 
-include_directories(${PROJECT_SOURCE_DIR}/src)
+# Import object targets =======================================================
 
-add_library(ramulator SHARED)
-set_target_properties(ramulator PROPERTIES
-  LIBRARY_OUTPUT_DIRECTORY  ${PROJECT_SOURCE_DIR}
+add_subdirectory(src)
+
+# Shared library target =======================================================
+
+add_library(ramulator2 SHARED)
+target_include_directories(ramulator2 PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
+  $<INSTALL_INTERFACE:include>
 )
 target_link_libraries(
-  ramulator
-  PUBLIC yaml-cpp
-  PUBLIC spdlog
+  ramulator2
+  PRIVATE
+    spdlog
+    yaml-cpp
+    ramulator2_base
+    ramulator2_test
+    ramulator2_frontend
+    ramulator2_translation
+    ramulator2_memory_system
+    ramulator2_addr_mapper
+    ramulator2_dram
+    ramulator2_controller
 )
 
-add_executable(ramulator-exe)
+# Executable target ===========================================================
+
+add_executable(ramulator2_main ${CMAKE_CURRENT_SOURCE_DIR}/src/main.cpp)
 target_link_libraries(
-  ramulator-exe
-  # PRIVATE -Wl,--whole-archive ramulator -Wl,--no-whole-archive
-  PRIVATE ramulator
-  PRIVATE argparse
+  ramulator2_main
+  PRIVATE
+    ramulator2
+    argparse
+    spdlog
+    yaml-cpp
 )
-
-set_target_properties(
-  ramulator-exe
-  PROPERTIES
+set_target_properties(ramulator2_main PROPERTIES
   OUTPUT_NAME ramulator2
 )
 
-add_subdirectory(src)
+# Install =====================================================================
+
+install(TARGETS ramulator2
+    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib
+    RUNTIME DESTINATION bin
+)
+
+install(TARGETS ramulator2_main
+    RUNTIME DESTINATION bin
+)
+
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/src/
+    DESTINATION include
+    FILES_MATCHING PATTERN "*.h"
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,10 +32,10 @@ option(YAML_CPP_BUILD_CONTRIB "Enable yaml-cpp contrib in library" OFF)
 option(YAML_CPP_BUILD_TOOLS "Enable parse tools" OFF)
 option(YAML_BUILD_SHARED_LIBS "Build yaml-cpp as a shared library" OFF)
 FetchContent_Declare(
-  yaml-cpp                             
+  yaml-cpp
   GIT_REPOSITORY https://github.com/jbeder/yaml-cpp.git
-  GIT_TAG        yaml-cpp-0.7.0                        
-  SOURCE_DIR     ${CMAKE_SOURCE_DIR}/ext/yaml-cpp
+  GIT_TAG        yaml-cpp-0.7.0
+  SOURCE_DIR     ${PROJECT_SOURCE_DIR}/ext/yaml-cpp
 )
 FetchContent_MakeAvailable(yaml-cpp)
 include_directories(${yaml-cpp_SOURCE_DIR}/include)
@@ -43,10 +43,10 @@ message("Done configuring yaml-cpp.")
 
 message("Configuring spdlog...")
 FetchContent_Declare(
-  spdlog                             
+  spdlog
   GIT_REPOSITORY https://github.com/gabime/spdlog.git
-  GIT_TAG        v1.11.0     
-  SOURCE_DIR     ${CMAKE_SOURCE_DIR}/ext/spdlog
+  GIT_TAG        v1.11.0
+  SOURCE_DIR     ${PROJECT_SOURCE_DIR}/ext/spdlog
 )
 FetchContent_MakeAvailable(spdlog)
 include_directories(${spdlog_SOURCE_DIR}/include)
@@ -56,37 +56,37 @@ message("Configuring argparse...")
 FetchContent_Declare(
     argparse
     GIT_REPOSITORY https://github.com/p-ranav/argparse.git
-    GIT_TAG        v2.9     
-    SOURCE_DIR     ${CMAKE_SOURCE_DIR}/ext/argparse
+    GIT_TAG        v2.9
+    SOURCE_DIR     ${PROJECT_SOURCE_DIR}/ext/argparse
 )
 FetchContent_MakeAvailable(argparse)
 include_directories(${argparse_SOURCE_DIR}/include)
 message("Done configuring argparse.")
 ##################################
 
-include_directories(${CMAKE_SOURCE_DIR}/src)
+include_directories(${PROJECT_SOURCE_DIR}/src)
 
 add_library(ramulator SHARED)
 set_target_properties(ramulator PROPERTIES
   LIBRARY_OUTPUT_DIRECTORY  ${PROJECT_SOURCE_DIR}
 )
 target_link_libraries(
-  ramulator 
+  ramulator
   PUBLIC yaml-cpp
   PUBLIC spdlog
 )
 
 add_executable(ramulator-exe)
 target_link_libraries(
-  ramulator-exe 
-  # PRIVATE -Wl,--whole-archive ramulator -Wl,--no-whole-archive 
+  ramulator-exe
+  # PRIVATE -Wl,--whole-archive ramulator -Wl,--no-whole-archive
   PRIVATE ramulator
   PRIVATE argparse
 )
 
 set_target_properties(
   ramulator-exe
-  PROPERTIES 
+  PROPERTIES
   OUTPUT_NAME ramulator2
 )
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,9 +6,3 @@ add_subdirectory(memory_system)
 add_subdirectory(addr_mapper)
 add_subdirectory(dram)
 add_subdirectory(dram_controller)
-
-target_sources(
-  ramulator-exe
-  PRIVATE 
-  main.cpp
-)

--- a/src/addr_mapper/CMakeLists.txt
+++ b/src/addr_mapper/CMakeLists.txt
@@ -1,16 +1,20 @@
-add_library(ramulator-addrmapper OBJECT)
+add_library(ramulator2_addr_mapper OBJECT)
 
-target_sources(
-  ramulator-addrmapper PRIVATE
-  addr_mapper.h 
-
-  impl/linear_mappers.cpp
-  impl/rit.cpp
-  impl/rit.h
+target_include_directories(ramulator2_addr_mapper PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR}/..
 )
 
-target_link_libraries(
-  ramulator
+target_sources(ramulator2_addr_mapper
+  PUBLIC
+    addr_mapper.h
+    impl/rit.h
+
   PRIVATE
-  ramulator-addrmapper
+    impl/linear_mappers.cpp
+    impl/rit.cpp
+)
+
+target_link_libraries(ramulator2_addr_mapper PRIVATE
+  spdlog
+  yaml-cpp
 )

--- a/src/base/CMakeLists.txt
+++ b/src/base/CMakeLists.txt
@@ -1,24 +1,35 @@
-add_library(ramulator-base OBJECT)
+add_library(ramulator2_base OBJECT)
 
-target_sources(
-  ramulator-base PRIVATE
-  base.h      
-  factory.h   factory.cpp
-  type.h
-  exception.h
-  logging.h   logging.cpp
-  debug.h
-  param.h 
-  utils.h     utils.cpp
-  config.h    config.cpp
-  clocked.h
-  stats.h     stats.cpp
-  request.h   request.cpp
-  serialization.h
+target_include_directories(ramulator2_base PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR}/..
 )
 
-target_link_libraries(
-  ramulator
+target_sources(ramulator2_base
+  PUBLIC
+    base.h
+    factory.h
+    type.h
+    exception.h
+    logging.h
+    debug.h
+    param.h
+    utils.h
+    config.h
+    clocked.h
+    stats.h
+    request.h
+    serialization.h
+
   PRIVATE
-  ramulator-base
+    factory.cpp
+    logging.cpp
+    utils.cpp
+    config.cpp
+    stats.cpp
+    request.cpp
+)
+
+target_link_libraries(ramulator2_base PRIVATE
+  spdlog
+  yaml-cpp
 )

--- a/src/base/logging.cpp
+++ b/src/base/logging.cpp
@@ -3,6 +3,9 @@
 
 namespace Ramulator {
 
+const std::string Logging::default_logger_pattern = "[%n] %^[%l]%$ %v";
+bool Logging::base_logger_registered = Logging::_create_base_logger();
+
 Logger_t Logging::create_logger(std::string name, std::string pattern) {
   auto logger = spdlog::stdout_color_st("Ramulator::" + name);
 

--- a/src/base/logging.h
+++ b/src/base/logging.h
@@ -17,29 +17,29 @@ using Logger_t = std::shared_ptr<spdlog::logger>;
 
 class Logging {
   private:
-    inline static const std::string default_logger_pattern = "[%n] %^[%l]%$ %v";
+    static const std::string default_logger_pattern;
 
   public:
     /**
      * @brief       Create an spdlog logger.
-     * 
+     *
      * @param name  The name of the logger
-     * @return Logger_t 
+     * @return Logger_t
      */
     static Logger_t create_logger(std::string name, std::string pattern = default_logger_pattern);
 
     /**
      * @brief       Returns a pointer to the logger by its name.
-     * 
-     * @param name 
-     * @return Logger_t 
+     *
+     * @param name
+     * @return Logger_t
      */
     static Logger_t get(std::string name);
 
   private:
     static bool _create_base_logger();
-    inline static bool base_logger_registered = _create_base_logger();
-    
+    static bool base_logger_registered;
+
   public:
     Logging() = delete;
     Logging(const Logging&) = delete;

--- a/src/dram/CMakeLists.txt
+++ b/src/dram/CMakeLists.txt
@@ -1,26 +1,36 @@
-add_library(ramulator-dram OBJECT)
+add_library(ramulator2_dram OBJECT)
 
-target_sources(
-  ramulator-dram PRIVATE
-  dram.h  node.h  spec.h  lambdas.h  
-  
-  lambdas/preq.h  lambdas/rowhit.h  lambdas/rowopen.h lambdas/action.h lambdas/power.h
-
-  impl/DDR3.cpp
-  impl/DDR4.cpp
-  impl/DDR4-VRR.cpp
-  impl/DDR4-RVRR.cpp
-  impl/DDR5.cpp
-  impl/DDR5-VRR.cpp
-  impl/DDR5-RVRR.cpp
-  impl/LPDDR5.cpp
-  impl/HBM.cpp
-  impl/HBM2.cpp
-  impl/HBM3.cpp
+target_include_directories(ramulator2_dram PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR}/..
 )
 
-target_link_libraries(
-  ramulator
+target_sources(ramulator2_dram
+  PUBLIC
+    dram.h
+    node.h
+    spec.h
+    lambdas.h
+    lambdas/preq.h
+    lambdas/rowhit.h
+    lambdas/rowopen.h
+    lambdas/action.h
+    lambdas/power.h
+
   PRIVATE
-  ramulator-dram
+    impl/DDR3.cpp
+    impl/DDR4.cpp
+    impl/DDR4-VRR.cpp
+    impl/DDR4-RVRR.cpp
+    impl/DDR5.cpp
+    impl/DDR5-VRR.cpp
+    impl/DDR5-RVRR.cpp
+    impl/LPDDR5.cpp
+    impl/HBM.cpp
+    impl/HBM2.cpp
+    impl/HBM3.cpp
+)
+
+target_link_libraries(ramulator2_dram PRIVATE
+  spdlog
+  yaml-cpp
 )

--- a/src/dram_controller/CMakeLists.txt
+++ b/src/dram_controller/CMakeLists.txt
@@ -1,58 +1,54 @@
-add_library(ramulator-controller OBJECT)
+add_library(ramulator2_controller OBJECT)
 
-target_sources(
-  ramulator-controller PRIVATE
-  bh_controller.h 
-  bh_scheduler.h 
-  controller.h 
-  scheduler.h 
-  plugin.h
-  refresh.h
-  rowpolicy.h
-
-  impl/bh_dram_controller.cpp
-  impl/dummy_controller.cpp
-  impl/generic_dram_controller.cpp
-  impl/prac_dram_controller.cpp
-  
-  impl/scheduler/bh_scheduler.cpp
-  impl/scheduler/blocking_scheduler.cpp
-  impl/scheduler/generic_scheduler.cpp
-  impl/scheduler/bliss_scheduler.cpp
-  impl/scheduler/prac_scheduler.cpp
-
-  impl/refresh/all_bank_refresh.cpp
-  
-  impl/rowpolicy/basic_rowpolicies.cpp
-
-  impl/plugin/trace_recorder.cpp
-  impl/plugin/cmd_counter.cpp
-  impl/plugin/para.cpp
-  impl/plugin/graphene.cpp
-  impl/plugin/oracle_rh.cpp
-  impl/plugin/twice.cpp
-  impl/plugin/hydra.cpp
-  impl/plugin/rrs.cpp
-  impl/plugin/aqua.cpp
-  impl/plugin/rfm_manager.cpp
-
-  impl/plugin/blockhammer/blockhammer_throttler.h 
-  impl/plugin/blockhammer/blockhammer_util.h 
-  impl/plugin/blockhammer/blockhammer.cpp 
-  impl/plugin/blockhammer/blockhammer.h 
-
-  impl/plugin/device_config/device_config.cpp 
-  impl/plugin/device_config/device_config.h 
-
-  impl/plugin/bliss/bliss.cpp 
-  impl/plugin/bliss/bliss.h 
-
-  impl/plugin/prac/prac.cpp 
-  impl/plugin/prac/prac.h 
+target_include_directories(ramulator2_controller PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR}/..
 )
 
-target_link_libraries(
-  ramulator
+target_sources(ramulator2_controller
+  PUBLIC
+    bh_controller.h
+    bh_scheduler.h
+    controller.h
+    scheduler.h
+    plugin.h
+    refresh.h
+    rowpolicy.h
+    impl/plugin/blockhammer/blockhammer_throttler.h
+    impl/plugin/blockhammer/blockhammer_util.h
+    impl/plugin/blockhammer/blockhammer.h
+    impl/plugin/device_config/device_config.h
+    impl/plugin/bliss/bliss.h
+    impl/plugin/prac/prac.h
+
   PRIVATE
-  ramulator-controller
+    impl/bh_dram_controller.cpp
+    impl/dummy_controller.cpp
+    impl/generic_dram_controller.cpp
+    impl/prac_dram_controller.cpp
+    impl/scheduler/bh_scheduler.cpp
+    impl/scheduler/blocking_scheduler.cpp
+    impl/scheduler/generic_scheduler.cpp
+    impl/scheduler/bliss_scheduler.cpp
+    impl/scheduler/prac_scheduler.cpp
+    impl/refresh/all_bank_refresh.cpp
+    impl/rowpolicy/basic_rowpolicies.cpp
+    impl/plugin/trace_recorder.cpp
+    impl/plugin/cmd_counter.cpp
+    impl/plugin/para.cpp
+    impl/plugin/graphene.cpp
+    impl/plugin/oracle_rh.cpp
+    impl/plugin/twice.cpp
+    impl/plugin/hydra.cpp
+    impl/plugin/rrs.cpp
+    impl/plugin/aqua.cpp
+    impl/plugin/rfm_manager.cpp
+    impl/plugin/blockhammer/blockhammer.cpp
+    impl/plugin/device_config/device_config.cpp
+    impl/plugin/bliss/bliss.cpp
+    impl/plugin/prac/prac.cpp
+)
+
+target_link_libraries(ramulator2_controller PRIVATE
+  spdlog
+  yaml-cpp
 )

--- a/src/example/CMakeLists.txt
+++ b/src/example/CMakeLists.txt
@@ -1,17 +1,23 @@
-add_library(ramulator-example OBJECT)
+add_library(ramulator2_example OBJECT)
 
-target_sources(
-  ramulator-example PRIVATE
-  example_ifce.h
-  impl/example_impl.cpp
-  impl/example_serialization.cpp
-  impl/complicated_impl.h   impl/complicated_impl.cpp
-  impl/another_impl.cpp
-  impl/yetanother_impl.cpp
+target_include_directories(ramulator2_example PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR}/..
 )
 
-target_link_libraries(
-  ramulator
+target_sources(ramulator2_example
+  PUBLIC
+    example_ifce.h
+    impl/complicated_impl.h
+
   PRIVATE
-  ramulator-example
+    impl/example_impl.cpp
+    impl/example_serialization.cpp
+    impl/complicated_impl.cpp
+    impl/another_impl.cpp
+    impl/yetanother_impl.cpp
+)
+
+target_link_libraries(ramulator2_example PRIVATE
+  spdlog
+  yaml-cpp
 )

--- a/src/frontend/CMakeLists.txt
+++ b/src/frontend/CMakeLists.txt
@@ -1,26 +1,33 @@
-add_library(ramulator-frontend OBJECT)
+add_library(ramulator2_frontend OBJECT)
 
-target_sources(
-  ramulator-frontend PRIVATE
-  frontend.h
-
-  impl/memory_trace/loadstore_trace.cpp
-  impl/memory_trace/readwrite_trace.cpp
-
-  impl/processor/simpleO3/simpleO3.cpp
-  impl/processor/simpleO3/core.h      impl/processor/simpleO3/core.cpp
-  impl/processor/simpleO3/llc.h       impl/processor/simpleO3/llc.cpp
-  impl/processor/simpleO3/trace.h     impl/processor/simpleO3/trace.cpp
-
-  impl/processor/bhO3/bhO3.h      impl/processor/bhO3/bhO3.cpp
-  impl/processor/bhO3/bhcore.h    impl/processor/bhO3/bhcore.cpp
-  impl/processor/bhO3/bhllc.h     impl/processor/bhO3/bhllc.cpp
-
-  impl/external_wrapper/gem5_frontend.cpp
+target_include_directories(ramulator2_frontend PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR}/..
 )
 
-target_link_libraries(
-  ramulator
+target_sources(ramulator2_frontend
+  PUBLIC
+    frontend.h
+    impl/processor/simpleO3/core.h
+    impl/processor/simpleO3/llc.h
+    impl/processor/simpleO3/trace.h
+    impl/processor/bhO3/bhO3.h
+    impl/processor/bhO3/bhcore.h
+    impl/processor/bhO3/bhllc.h
+
   PRIVATE
-  ramulator-frontend
+    impl/memory_trace/loadstore_trace.cpp
+    impl/memory_trace/readwrite_trace.cpp
+    impl/processor/simpleO3/simpleO3.cpp
+    impl/processor/simpleO3/core.cpp
+    impl/processor/simpleO3/llc.cpp
+    impl/processor/simpleO3/trace.cpp
+    impl/processor/bhO3/bhO3.cpp
+    impl/processor/bhO3/bhcore.cpp
+    impl/processor/bhO3/bhllc.cpp
+    impl/external_wrapper/gem5_frontend.cpp
+)
+
+target_link_libraries(ramulator2_frontend PRIVATE
+  spdlog
+  yaml-cpp
 )

--- a/src/memory_system/CMakeLists.txt
+++ b/src/memory_system/CMakeLists.txt
@@ -1,17 +1,21 @@
-add_library(ramulator-memorysystem OBJECT)
+add_library(ramulator2_memory_system OBJECT)
 
-target_sources(
-  ramulator-memorysystem PRIVATE
-  bh_memory_system.h
-  memory_system.h
-
-  impl/bh_DRAM_system.cpp
-  impl/dummy_memory_system.cpp
-  impl/generic_DRAM_system.cpp
+target_include_directories(ramulator2_memory_system PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR}/..
 )
 
-target_link_libraries(
-  ramulator
+target_sources(ramulator2_memory_system
+  PUBLIC
+    bh_memory_system.h
+    memory_system.h
+
   PRIVATE
-  ramulator-memorysystem
+    impl/bh_DRAM_system.cpp
+    impl/dummy_memory_system.cpp
+    impl/generic_DRAM_system.cpp
+)
+
+target_link_libraries(ramulator2_memory_system PRIVATE
+  spdlog
+  yaml-cpp
 )

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -1,13 +1,18 @@
-add_library(ramulator-test OBJECT)
+add_library(ramulator2_test OBJECT)
 
-target_sources(
-  ramulator-test PRIVATE
-  test_ifce.h
-  test_impl.cpp
+target_include_directories(ramulator2_test PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR}/..
 )
 
-target_link_libraries(
-  ramulator
+target_sources(ramulator2_test
+  PUBLIC
+    test_ifce.h
+
   PRIVATE
-  ramulator-test
+    test_impl.cpp
+)
+
+target_link_libraries(ramulator2_test PRIVATE
+  spdlog
+  yaml-cpp
 )

--- a/src/translation/CMakeLists.txt
+++ b/src/translation/CMakeLists.txt
@@ -1,15 +1,19 @@
-add_library(ramulator-translation OBJECT)
+add_library(ramulator2_translation OBJECT)
 
-target_sources(
-  ramulator-translation PRIVATE
-  translation.h
-
-  impl/no_translation.cpp
-  impl/random_translation.cpp
+target_include_directories(ramulator2_translation PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR}/..
 )
 
-target_link_libraries(
-  ramulator
+target_sources(ramulator2_translation
+  PUBLIC
+    translation.h
+
   PRIVATE
-  ramulator-translation
+    impl/no_translation.cpp
+    impl/random_translation.cpp
+)
+
+target_link_libraries(ramulator2_translation PRIVATE
+  spdlog
+  yaml-cpp
 )


### PR DESCRIPTION
This pull request primarily involves modifications to the project's CMakeLists.txt files. The goal was to enable the use of Ramulator2 as a CMake dependency for other projects. For more details, please refer to the commit messages.