### PR TITLE
Fix LPDDR5 open row incorrect detection

### DIFF
--- a/src/dram/impl/LPDDR5.cpp
+++ b/src/dram/impl/LPDDR5.cpp
@@ -460,7 +460,7 @@ class LPDDR5 : public IDRAM, public Implementation {
           case m_states["Closed"]: return m_commands["ACT-1"];
           case m_states["Pre-Opened"]: return m_commands["ACT-2"];
           case m_states["Opened"]: {
-            if (node->m_row_state.find(0) != node->m_row_state.end()) {
+            if (node->m_row_state.find(addr_vec[m_levels["row"]]) != node->m_row_state.end()) {
               Node* rank = node->m_parent_node->m_parent_node;
               if (rank->m_final_synced_cycle < clk) {
                 return m_commands["CASRD"];
@@ -482,7 +482,7 @@ class LPDDR5 : public IDRAM, public Implementation {
           case m_states["Closed"]: return m_commands["ACT-1"];
           case m_states["Pre-Opened"]: return m_commands["ACT-2"];
           case m_states["Opened"]: {
-            if (node->m_row_state.find(0) != node->m_row_state.end()) {
+            if (node->m_row_state.find(addr_vec[m_levels["row"]]) != node->m_row_state.end()) {
               Node* rank = node->m_parent_node->m_parent_node;
               if (rank->m_final_synced_cycle < clk) {
                 return m_commands["CASWR"];


### PR DESCRIPTION
LPDDR5 execution hangs indefinitely (or triggers refresh watchdog) because it does not check for the correct row state, generating an infinite sequence of precharge commands. This commit fixes this behavior by using the correct row index.

Fixes issue #58.