### PR TITLE
Fix typo in RowOpen lambda

### DIFF
--- a/src/dram/lambdas/rowopen.h
+++ b/src/dram/lambdas/rowopen.h
@@ -14,13 +14,13 @@ namespace Bank {
       case T::m_states["Opened"]: return true;
       case T::m_states["Refreshing"]: return false;
       default: {
-        spdlog::error("[RowHit::Bank] Invalid bank state for an RD/WR command!");
+        spdlog::error("[RowOpen::Bank] Invalid bank state for an RD/WR command!");
         std::exit(-1);      
       }
     }
   }
 }       // namespace Bank
-}       // namespace RowHit
+}       // namespace RowOpen
 }       // namespace Lambdas
 };      // namespace Ramulator
 


### PR DESCRIPTION
The spdlog error message and one of the comments
reported RowHit instead of RowOpen.