### PR TITLE
Do not exceed maximum buffer size

### DIFF
--- a/src/base/request.h
+++ b/src/base/request.h
@@ -57,7 +57,7 @@ struct ReqBuffer {
   size_t size() const { return buffer.size(); }
 
   bool enqueue(const Request& request) {
-    if (buffer.size() <= max_size) {
+    if (buffer.size() < max_size) {
       buffer.push_back(request);
       return true;
     } else {


### PR DESCRIPTION
With the previous condition, the buffer allowed for an extra request to be enqueued, which exceeded the maximum size by 1.