### PR TITLE
wrapper:delay startup

### DIFF
--- a/resources/gem5_wrappers/ramulator2.cc
+++ b/resources/gem5_wrappers/ramulator2.cc
@@ -68,7 +68,7 @@ Ramulator2::startup()
     startTick = curTick();
 
     // kick off the clock ticks
-    schedule(tickEvent, clockEdge());
+    schedule(tickEvent, 10000000000000);
 }
 
 void


### PR DESCRIPTION
This PR fix #78 error.

After gem5 write disk-image to main-memory calling recvFunctional(), gem5 trigger startup() and sendAtomic request to memory waiting linux-booting.

However, the current wrapper trigger tickEvent as soon as startup(). That interrupts atomic requests and booting is failed.

If tickEvent is delayed sufficiently, the problem is solved.
