### PR TITLE
Bug when active buffer full and try to enqueue a new request in diffrent mem controller implementation fixed

### DIFF
--- a/src/dram_controller/impl/bh_dram_controller.cpp
+++ b/src/dram_controller/impl/bh_dram_controller.cpp
@@ -168,8 +168,9 @@ class BHDRAMController final : public IBHDRAMController, public Implementation {
           buffer->remove(req_it);
         } else {
           if (m_dram->m_command_meta(req_it->command).is_opening) {
-            m_active_buffer.enqueue(*req_it);
-            buffer->remove(req_it);
+            if (m_active_buffer.enqueue(*req_it)) {
+              buffer->remove(req_it);
+            }
           }
         }
       }

--- a/src/dram_controller/impl/generic_dram_controller.cpp
+++ b/src/dram_controller/impl/generic_dram_controller.cpp
@@ -214,8 +214,9 @@ class GenericDRAMController final : public IDRAMController, public Implementatio
           buffer->remove(req_it);
         } else {
           if (m_dram->m_command_meta(req_it->command).is_opening) {
-            m_active_buffer.enqueue(*req_it);
-            buffer->remove(req_it);
+            if (m_active_buffer.enqueue(*req_it)) {
+              buffer->remove(req_it);
+            }
           }
         }
 

--- a/src/dram_controller/impl/prac_dram_controller.cpp
+++ b/src/dram_controller/impl/prac_dram_controller.cpp
@@ -212,8 +212,9 @@ public:
                 buffer->remove(req_it);
             }
             else if (m_dram->m_command_meta(req_it->command).is_opening) {
-                m_active_buffer.enqueue(*req_it);
+              if (m_active_buffer.enqueue(*req_it)) {
                 buffer->remove(req_it);
+              }
             }
         }
 


### PR DESCRIPTION
I just fixed a bug occurring for multiple memory controller implementationss. When the active buffer was full, the founded request was not pushed in the a active buffer and was removed from the command buffer. As a result some requests were not issued.

Fix:
If the active buffer is full the founded request is not removed from the command buffer.
