### PR TITLE
Fix compilation error with clang due to incorrect template usage

### DIFF
--- a/src/base/param.h
+++ b/src/base/param.h
@@ -88,7 +88,7 @@ class _ParamChainer {
 
       if (_config[_name]) {
         try {
-          return _config[_name].as<T>();
+          return _config[_name].template as<T>();
         } catch (const YAML::BadConversion& e) {
           throw ConfigurationError("Failed to parse Param \"{}\" for implementation \"{}\".", _name_prefix + _name, _impl_name);
         }


### PR DESCRIPTION
Use template keyword to disambiguate dependent names in param.h when using clang compiler:

```
./ramulator2/src/base/param.h:91:33: error: use 'template' keyword to treat 'as' as a dependent template name
   91 |           return _config[_name].as<T>();
      |                                 ^
      |                                 template
```

This change ensures compatibility with clang's parsing rules for dependent names.