### PR TITLE
Fix logic error in scheduler of DRAM controllers

### DIFF
--- a/src/dram_controller/impl/bh_dram_controller.cpp
+++ b/src/dram_controller/impl/bh_dram_controller.cpp
@@ -245,7 +245,7 @@ class BHDRAMController final : public IBHDRAMController, public Implementation {
           req_it->command = m_dram->get_preq_command(req_it->final_command, req_it->addr_vec);
           
           request_found = m_dram->check_ready(req_it->command, req_it->addr_vec);
-          if (!request_found & m_priority_buffer.size() != 0) {
+          if (!request_found && m_priority_buffer.size() != 0) {
             return false;
           }
         }

--- a/src/dram_controller/impl/generic_dram_controller.cpp
+++ b/src/dram_controller/impl/generic_dram_controller.cpp
@@ -358,7 +358,7 @@ class GenericDRAMController final : public IDRAMController, public Implementatio
           req_it->command = m_dram->get_preq_command(req_it->final_command, req_it->addr_vec);
           
           request_found = m_dram->check_ready(req_it->command, req_it->addr_vec);
-          if (!request_found & m_priority_buffer.size() != 0) {
+          if (!request_found && m_priority_buffer.size() != 0) {
             return false;
           }
         }

--- a/src/dram_controller/impl/prac_dram_controller.cpp
+++ b/src/dram_controller/impl/prac_dram_controller.cpp
@@ -293,7 +293,7 @@ private:
                 bool is_pre_rec = m_prac->get_state() == IPRAC::ABOState::PRE_RECOVERY;
                 bool early_issue = is_rfm && is_pre_rec; // Prevent controller from issuing RFMab before recovery starts
                 request_found = !early_issue && m_dram->check_ready(req_it->command, req_it->addr_vec);
-                if (!request_found & m_prac_buffer.size() != 0) {
+                if (!request_found && m_prac_buffer.size() != 0) {
                     return false;
                 }
             }
@@ -306,7 +306,7 @@ private:
 
                 bool fits = m_clk + m_prac->min_cycles_with_preall(req_it) < next_recovery_clk;
                 request_found = fits && m_dram->check_ready(req_it->command, req_it->addr_vec);
-                if (!request_found & m_priority_buffer.size() != 0) {
+                if (!request_found && m_priority_buffer.size() != 0) {
                     return false;
                 }
             }


### PR DESCRIPTION
Updated the condition to check for both request_found and buffer size in the scheduler logic, which previously uses a bitwise AND operator '&' instead of the logical AND operator '&&'.