### PR TITLE
refactor: eliminate circular header dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ ext/
 ramulator2
 *.so
 autobuild.sh
+.cache

--- a/src/dram_controller/impl/generic_dram_controller.cpp
+++ b/src/dram_controller/impl/generic_dram_controller.cpp
@@ -1,5 +1,6 @@
 #include "dram_controller/controller.h"
 #include "memory_system/memory_system.h"
+#include "frontend/frontend.h"
 
 namespace Ramulator {
 
@@ -8,7 +9,7 @@ class GenericDRAMController final : public IDRAMController, public Implementatio
   private:
     std::deque<Request> pending;          // A queue for read requests that are about to finish (callback after RL)
 
-    ReqBuffer m_active_buffer;            // Buffer for requests being served. This has the highest priority 
+    ReqBuffer m_active_buffer;            // Buffer for requests being served. This has the highest priority
     ReqBuffer m_priority_buffer;          // Buffer for high-priority requests (e.g., maintenance like refresh).
     ReqBuffer m_read_buffer;              // Read request buffer
     ReqBuffer m_write_buffer;             // Write request buffer
@@ -56,8 +57,8 @@ class GenericDRAMController final : public IDRAMController, public Implementatio
       m_wr_high_watermark = param<float>("wr_high_watermark").desc("Threshold for switching to write mode.").default_val(0.8f);
 
       m_scheduler = create_child_ifce<IScheduler>();
-      m_refresh = create_child_ifce<IRefreshManager>();    
-      m_rowpolicy = create_child_ifce<IRowPolicy>();    
+      m_refresh = create_child_ifce<IRefreshManager>();
+      m_rowpolicy = create_child_ifce<IRowPolicy>();
 
       if (m_config["plugins"]) {
         YAML::Node plugin_configs = m_config["plugins"];
@@ -229,7 +230,7 @@ class GenericDRAMController final : public IDRAMController, public Implementatio
     /**
      * @brief    Helper function to check if a request is hitting an open row
      * @details
-     * 
+     *
      */
     bool is_row_hit(ReqBuffer::iterator& req)
     {
@@ -238,7 +239,7 @@ class GenericDRAMController final : public IDRAMController, public Implementatio
     /**
      * @brief    Helper function to check if a request is opening a row
      * @details
-     * 
+     *
     */
     bool is_row_open(ReqBuffer::iterator& req)
     {
@@ -246,15 +247,15 @@ class GenericDRAMController final : public IDRAMController, public Implementatio
     }
 
     /**
-     * @brief    
+     * @brief
      * @details
-     * 
+     *
      */
     void update_request_stats(ReqBuffer::iterator& req)
     {
       req->is_stat_updated = true;
 
-      if (req->type_id == Request::Type::Read) 
+      if (req->type_id == Request::Type::Read)
       {
         if (is_row_hit(req)) {
           s_read_row_hits++;
@@ -271,9 +272,9 @@ class GenericDRAMController final : public IDRAMController, public Implementatio
           s_row_misses++;
           if (req->source_id != -1)
             s_read_row_misses_per_core[req->source_id]++;
-        } 
-      } 
-      else if (req->type_id == Request::Type::Write) 
+        }
+      }
+      else if (req->type_id == Request::Type::Write)
       {
         if (is_row_hit(req)) {
           s_write_row_hits++;
@@ -320,7 +321,7 @@ class GenericDRAMController final : public IDRAMController, public Implementatio
 
     /**
      * @brief    Checks if we need to switch to write mode
-     * 
+     *
      */
     void set_write_mode() {
       if (!m_is_write_mode) {
@@ -337,7 +338,7 @@ class GenericDRAMController final : public IDRAMController, public Implementatio
 
     /**
      * @brief    Helper function to find a request to schedule from the buffers.
-     * 
+     *
      */
     bool schedule_request(ReqBuffer::iterator& req_it, ReqBuffer*& req_buffer) {
       bool request_found = false;
@@ -356,7 +357,7 @@ class GenericDRAMController final : public IDRAMController, public Implementatio
           req_buffer = &m_priority_buffer;
           req_it = m_priority_buffer.begin();
           req_it->command = m_dram->get_preq_command(req_it->final_command, req_it->addr_vec);
-          
+
           request_found = m_dram->check_ready(req_it->command, req_it->addr_vec);
           if (!request_found & m_priority_buffer.size() != 0) {
             return false;
@@ -411,5 +412,5 @@ class GenericDRAMController final : public IDRAMController, public Implementatio
     }
 
 };
-  
+
 }   // namespace Ramulator

--- a/src/dram_controller/impl/plugin/aqua.cpp
+++ b/src/dram_controller/impl/plugin/aqua.cpp
@@ -9,6 +9,7 @@
 #include "translation/translation.h"
 #include "addr_mapper/impl/rit.h"
 #include "dram_controller/impl/plugin/device_config/device_config.h"
+#include "frontend/frontend.h"
 
 namespace Ramulator {
 
@@ -66,7 +67,7 @@ class AQUA : public IControllerPlugin, public Implementation {
     int s_num_r_migrations = 0;
 
   public:
-    void init() override { 
+    void init() override {
       m_num_art_entries = param<int>("num_art_entries").required();
       m_num_fpt_entries = param<int>("num_fpt_entries").required();
       m_num_qrows_per_bank = param<int>("num_qrows_per_bank").required();
@@ -94,8 +95,8 @@ class AQUA : public IControllerPlugin, public Implementation {
       m_col_level = m_dram->m_levels("column");
 
       m_num_ranks = m_dram->get_level_size("rank");
-      m_num_banks_per_rank = m_dram->get_level_size("bankgroup") == -1 ? 
-                             m_dram->get_level_size("bank") : 
+      m_num_banks_per_rank = m_dram->get_level_size("bankgroup") == -1 ?
+                             m_dram->get_level_size("bank") :
                              m_dram->get_level_size("bankgroup") * m_dram->get_level_size("bank");
       m_num_rows_per_bank = m_dram->get_level_size("row");
       m_num_cls = m_dram->get_level_size("column") / 8;
@@ -114,7 +115,7 @@ class AQUA : public IControllerPlugin, public Implementation {
       m_addr_mapper->init_rit(m_num_banks_per_rank * m_num_ranks, m_num_fpt_entries * 2);
 
       reserve_rows_for_aqua();
-      
+
       // setup random number generator
       generator = std::mt19937(1337);
       distribution = std::uniform_int_distribution<int>(0, m_num_rows_per_bank-1);
@@ -155,7 +156,7 @@ class AQUA : public IControllerPlugin, public Implementation {
             accumulated_dimension *= m_dram->m_organization.count[i + 1];
             flat_bank_id += req_it->addr_vec[i] * accumulated_dimension;
           }
-          
+
           int row_id = req_it->addr_vec[m_row_level];
 
           if (m_is_debug) {
@@ -169,7 +170,7 @@ class AQUA : public IControllerPlugin, public Implementation {
             if (m_is_debug) {
               std::cout << "  └  " << "row " << row_id << " not in HRT." << std::endl;
             }
-            // if row is not in the table, check if the table is full 
+            // if row is not in the table, check if the table is full
             if (m_aggressor_row_tracker[flat_bank_id].size() < m_num_art_entries) {
               if (m_is_debug) {
                 std::cout << "  └  " << "HRT is not full, inserting with count 1." << std::endl;
@@ -218,7 +219,7 @@ class AQUA : public IControllerPlugin, public Implementation {
               }
             }
           } else {
-            if (m_is_debug) { 
+            if (m_is_debug) {
               std::cout << "  └  " << "row " << row_id << " in HRT. Incrementing its counter." << std::endl;
             }
             // if row in table, increment its activation count
@@ -229,7 +230,7 @@ class AQUA : public IControllerPlugin, public Implementation {
           //   std::cout << "==========================" << std::endl;
           //   std::cout << "HRT[" << flat_bank_id << "].size(): " << m_hot_row_tracker[flat_bank_id].size() << std::endl;
           //   for (auto entry: m_hot_row_tracker[flat_bank_id]) {
-          //     std::cout << entry.first << ":\t" << entry.second << std::endl; 
+          //     std::cout << entry.first << ":\t" << entry.second << std::endl;
           //   }
           //   std::cout << "Spillover counter: " << m_spillover_counter[flat_bank_id] << std::endl;
           //   std::cout << "==========================" << std::endl;
@@ -290,7 +291,7 @@ class AQUA : public IControllerPlugin, public Implementation {
               m_reverse_pointer_table[flat_bank_id][m_rqa_head] = row_id;
               m_addr_mapper->rit_insert_entry(flat_bank_id, row_id, m_rqa_head);
             }
-            
+
             s_num_migrations++;
             // update rqa head
             m_rqa_head = (m_rqa_head + 1) % m_num_qrows_per_bank;
@@ -306,7 +307,7 @@ class AQUA : public IControllerPlugin, public Implementation {
         addr_vec.push_back(req_it->addr_vec[i]);
       }
 
-      // Read src_row to copy buffer 
+      // Read src_row to copy buffer
       addr_vec[m_row_level] = src_row;
       for (int cl = 0; cl < m_num_cls; cl++){
         addr_vec[m_col_level] = cl << 3;

--- a/src/dram_controller/impl/plugin/hydra.cpp
+++ b/src/dram_controller/impl/plugin/hydra.cpp
@@ -11,6 +11,7 @@
 #include "addr_mapper/addr_mapper.h"
 #include "dram_controller/controller.h"
 #include "dram_controller/plugin.h"
+#include "memory_system/memory_system.h"
 
 namespace Ramulator {
 
@@ -70,7 +71,7 @@ class Hydra : public IControllerPlugin, public Implementation {
     int m_rct_per_cl = -1;
     int m_group_rct_cl_size = -1;
 
-    // per bank GCT, 
+    // per bank GCT,
     // the first index is the flat bank id
     // the second index is the row group id
     // each entry has a group counter and a flag indicating if the group counter has beed initialized
@@ -115,7 +116,7 @@ class Hydra : public IControllerPlugin, public Implementation {
     bool m_is_debug;
 
   public:
-    void init() override { 
+    void init() override {
       m_tracking_threshold = param<int>("hydra_tracking_threshold").required();
       m_group_threshold = param<int>("hydra_group_threshold").required();
       m_row_group_size = param<int>("hydra_row_group_size").default_val(128);
@@ -149,8 +150,8 @@ class Hydra : public IControllerPlugin, public Implementation {
       m_col_level = m_dram->m_levels("column");
 
       m_num_ranks = m_dram->get_level_size("rank");
-      m_num_banks_per_rank = m_dram->get_level_size("bankgroup") == -1 ? 
-                             m_dram->get_level_size("bank") : 
+      m_num_banks_per_rank = m_dram->get_level_size("bankgroup") == -1 ?
+                             m_dram->get_level_size("bank") :
                              m_dram->get_level_size("bankgroup") * m_dram->get_level_size("bank");
       m_num_rows_per_bank = m_dram->get_level_size("row");
       m_num_cls = m_dram->get_level_size("column") / 8;
@@ -190,7 +191,7 @@ class Hydra : public IControllerPlugin, public Implementation {
         }
         row_count_cache.push_back(rcc_rank);
       }
-      
+
       for (int i = 0; i < m_num_ranks * m_num_banks_per_rank; i++) {
         std::unordered_map<Addr_t, int> row_count_table_bank;
         row_count_table.push_back(row_count_table_bank);
@@ -283,13 +284,13 @@ class Hydra : public IControllerPlugin, public Implementation {
             accumulated_dimension *= m_dram->m_organization.count[i + 1];
             flat_bank_id += req_it->addr_vec[i] * accumulated_dimension;
           }
-          
+
           uint rank_id = req_it->addr_vec[m_rank_level];
           uint bank_id = flat_bank_id % m_num_banks_per_rank;
           uint row_id = req_it->addr_vec[m_row_level];
           uint gct_index = row_id >> (m_row_address_bits - m_gct_index_bits); // get most significant bits
           uint rcc_index = row_id & ((1 << m_rcc_index_bits) - 1); // get least significant bits
-          uint rcc_tag = row_id >> (m_row_address_bits - m_rcc_tag_row_bits) // most significant bits of row_id 
+          uint rcc_tag = row_id >> (m_row_address_bits - m_rcc_tag_row_bits) // most significant bits of row_id
                           | bank_id << m_rcc_tag_row_bits; // bank_id
 
           if (m_is_debug) {
@@ -349,7 +350,7 @@ class Hydra : public IControllerPlugin, public Implementation {
           if (group_count_table[flat_bank_id][gct_index].group_count >= m_group_threshold){
             if (m_is_debug) {
               std::cout << "Hydra: Checking GCT" << std::endl;
-              std::cout << "Hydra: GCT above threshold " 
+              std::cout << "Hydra: GCT above threshold "
                         << group_count_table[flat_bank_id][gct_index].group_count << std::endl;
             }
 
@@ -378,7 +379,7 @@ class Hydra : public IControllerPlugin, public Implementation {
                 Request rct_init_req(rct_init_addr_vec, m_WR_req_id);
                 m_ctrl->priority_send(rct_init_req);
                 s_num_write_req++;
-                
+
                 if (m_is_debug) {
                   std::cout << "Hydra: Group initializing, generating write request to DRAM for RCT" << std::endl
                             << "        rct_bank: " << flat_bank_id << std::endl
@@ -463,7 +464,7 @@ class Hydra : public IControllerPlugin, public Implementation {
               // insert new entry and increment rcc
               row_count_table[flat_bank_id][row_id]++;
               row_count_cache[rank_id][rcc_index][rcc_tag] = row_count_table[flat_bank_id][row_id];
-              
+
               if (m_is_debug) {
                 std::cout << "Hydra: Generating read request to DRAM for RCT" << std::endl
                           << "        rct_bank: " << flat_bank_id << std::endl

--- a/src/frontend/frontend.h
+++ b/src/frontend/frontend.h
@@ -6,10 +6,11 @@
 #include <functional>
 
 #include "base/base.h"
-#include "memory_system/memory_system.h"
 
 
 namespace Ramulator {
+
+class IMemorySystem;
 
 class IFrontEnd : public Clocked<IFrontEnd>, public TopLevel<IFrontEnd> {
   RAMULATOR_REGISTER_INTERFACE(IFrontEnd, "Frontend", "The frontend that drives the simulation.");
@@ -21,8 +22,8 @@ class IFrontEnd : public Clocked<IFrontEnd>, public TopLevel<IFrontEnd> {
     uint m_clock_ratio = 1;
 
   public:
-    virtual void connect_memory_system(IMemorySystem* memory_system) { 
-      m_memory_system = memory_system; 
+    virtual void connect_memory_system(IMemorySystem* memory_system) {
+      m_memory_system = memory_system;
       m_impl->setup(this, memory_system);
       for (auto component : m_components) {
         component->setup(this, memory_system);
@@ -31,7 +32,7 @@ class IFrontEnd : public Clocked<IFrontEnd>, public TopLevel<IFrontEnd> {
 
     virtual bool is_finished() = 0;
 
-    virtual void finalize() { 
+    virtual void finalize() {
       for (auto component : m_components) {
         component->finalize();
       }
@@ -49,11 +50,11 @@ class IFrontEnd : public Clocked<IFrontEnd>, public TopLevel<IFrontEnd> {
 
     /**
      * @brief    Receives memory requests from external sources (e.g., coming from a full system simulator like GEM5)
-     * 
+     *
      * @details
      * This functions should take memory requests from external sources (e.g., coming from GEM5), generate Ramulator 2 Requests,
      * (tries to) send to the memory system, and return if this is successful
-     * 
+     *
      */
     virtual bool receive_external_requests(int req_type_id, Addr_t addr, int source_id, std::function<void(Request&)> callback) { return false; }
 };

--- a/src/frontend/impl/external_wrapper/gem5_frontend.cpp
+++ b/src/frontend/impl/external_wrapper/gem5_frontend.cpp
@@ -3,6 +3,7 @@
 #include <fstream>
 
 #include "frontend/frontend.h"
+#include "memory_system/memory_system.h"
 #include "base/exception.h"
 
 namespace Ramulator {

--- a/src/frontend/impl/memory_trace/loadstore_trace.cpp
+++ b/src/frontend/impl/memory_trace/loadstore_trace.cpp
@@ -3,6 +3,7 @@
 #include <fstream>
 
 #include "frontend/frontend.h"
+#include "memory_system/memory_system.h"
 #include "base/exception.h"
 
 namespace Ramulator {
@@ -70,7 +71,7 @@ class LoadStoreTrace : public IFrontEnd, public Implementation {
           throw ConfigurationError("Trace {} format invalid!", file_path_str);
         }
 
-        bool is_write = false; 
+        bool is_write = false;
         if (tokens[0] == "LD") {
           is_write = false;
         } else if (tokens[0] == "ST") {
@@ -95,7 +96,7 @@ class LoadStoreTrace : public IFrontEnd, public Implementation {
 
     // TODO: FIXME
     bool is_finished() override {
-      return m_trace_count >= m_trace_length; 
+      return m_trace_count >= m_trace_length;
     };
 };
 

--- a/src/frontend/impl/memory_trace/readwrite_trace.cpp
+++ b/src/frontend/impl/memory_trace/readwrite_trace.cpp
@@ -3,6 +3,7 @@
 #include <fstream>
 
 #include "frontend/frontend.h"
+#include "memory_system/memory_system.h"
 #include "base/exception.h"
 
 namespace Ramulator {
@@ -32,7 +33,7 @@ class ReadWriteTrace : public IFrontEnd, public Implementation {
       m_logger = Logging::create_logger("ReadWriteTrace");
       m_logger->info("Loading trace file {} ...", trace_path_str);
       init_trace(trace_path_str);
-      m_logger->info("Loaded {} lines.", m_trace.size());      
+      m_logger->info("Loaded {} lines.", m_trace.size());
     };
 
 
@@ -65,7 +66,7 @@ class ReadWriteTrace : public IFrontEnd, public Implementation {
           throw ConfigurationError("Trace {} format invalid!", file_path_str);
         }
 
-        bool is_write = false; 
+        bool is_write = false;
         if (tokens[0] == "R") {
           is_write = false;
         } else if (tokens[0] == "W") {
@@ -92,8 +93,8 @@ class ReadWriteTrace : public IFrontEnd, public Implementation {
 
     // TODO: FIXME
     bool is_finished() override {
-      return true; 
-    };    
+      return true;
+    };
 };
 
 }        // namespace Ramulator

--- a/src/memory_system/memory_system.h
+++ b/src/memory_system/memory_system.h
@@ -7,9 +7,11 @@
 #include <functional>
 
 #include "base/base.h"
-#include "frontend/frontend.h"
+
 
 namespace Ramulator {
+
+class IFrontEnd;
 
 class IMemorySystem : public TopLevel<IMemorySystem> {
   RAMULATOR_REGISTER_INTERFACE(IMemorySystem, "MemorySystem", "Memory system interface (e.g., communicates between processor and memory controller).")
@@ -21,15 +23,15 @@ class IMemorySystem : public TopLevel<IMemorySystem> {
     uint m_clock_ratio = 1;
 
   public:
-    virtual void connect_frontend(IFrontEnd* frontend) { 
-      m_frontend = frontend; 
+    virtual void connect_frontend(IFrontEnd* frontend) {
+      m_frontend = frontend;
       m_impl->setup(frontend, this);
       for (auto component : m_components) {
         component->setup(frontend, this);
       }
     };
 
-    virtual void finalize() { 
+    virtual void finalize() {
       for (auto component : m_components) {
         component->finalize();
       }
@@ -43,7 +45,7 @@ class IMemorySystem : public TopLevel<IMemorySystem> {
 
     /**
      * @brief         Tries to send the request to the memory system
-     * 
+     *
      * @param    req      The request
      * @return   true     Request is accepted by the memory system.
      * @return   false    Request is rejected by the memory system, maybe the memory controller is full?
@@ -52,20 +54,20 @@ class IMemorySystem : public TopLevel<IMemorySystem> {
 
     /**
      * @brief         Ticks the memory system
-     * 
+     *
      */
     virtual void tick() = 0;
 
     /**
-     * @brief    Returns 
-     * 
-     * @return   int 
+     * @brief    Returns
+     *
+     * @return   int
      */
     int get_clock_ratio() { return m_clock_ratio; };
 
     // /**
     //  * @brief    Get the integer id of the request type from the memory spec
-    //  * 
+    //  *
     //  */
     // virtual const SpecDef& get_supported_requests() = 0;
 


### PR DESCRIPTION
The commit also includes deleting redundant spaces, it compiles successfully.
It doesn't have the clang static analyzer warning for those files anymore.