### PR TITLE
Bug: Correctly mark arrived clock cycle for forwarded requests

### DIFF
--- a/src/dram_controller/impl/bh_dram_controller.cpp
+++ b/src/dram_controller/impl/bh_dram_controller.cpp
@@ -192,7 +192,7 @@ class BHDRAMController final : public IBHDRAMController, public Implementation {
         auto& req = pending[0];
         if (req.depart <= m_clk) {
           // Request received data from dram
-          if (req.depart - req.arrive > 1) {
+          if (req.depart - req.arrive >= 1) {
             // Check if this requests accesses the DRAM or is being forwarded.
             // TODO add the stats back
           }

--- a/src/dram_controller/impl/generic_dram_controller.cpp
+++ b/src/dram_controller/impl/generic_dram_controller.cpp
@@ -302,7 +302,7 @@ class GenericDRAMController final : public IDRAMController, public Implementatio
         auto& req = pending[0];
         if (req.depart <= m_clk) {
           // Request received data from dram
-          if (req.depart - req.arrive > 1) {
+          if (req.depart - req.arrive >= 1) {
             // Check if this requests accesses the DRAM or is being forwarded.
             // TODO add the stats back
             s_read_latency += req.depart - req.arrive;

--- a/src/dram_controller/impl/prac_dram_controller.cpp
+++ b/src/dram_controller/impl/prac_dram_controller.cpp
@@ -235,7 +235,7 @@ private:
             auto& req = pending[0];
             if (req.depart <= m_clk) {
                 // Request received data from dram
-                if (req.depart - req.arrive > 1) {
+                if (req.depart - req.arrive >= 1) {
                     // Check if this requests accesses the DRAM or is being forwarded.
                     // TODO add the stats back
                 }


### PR DESCRIPTION
The `arrive` time for forwarded read requests is unassigned, and this leads to read request latency being equal to `m_clk` instead of 1, as expected.

This PR assigns arrive cycle for forwarded requests, and accounts for these requests in latency calculation as they are counted in the number of requests issued by the memory system in the existing implementation.