### PR TITLE
fix: add missing close-row and open-row requests to LPDDR5

### DIFF
--- a/src/dram/impl/LPDDR5.cpp
+++ b/src/dram/impl/LPDDR5.cpp
@@ -77,16 +77,18 @@ class LPDDR5 : public IDRAM, public Implementation {
 
     inline static constexpr ImplDef m_requests = {
       "read16", "write16",
-      "all-bank-refresh", "per-bank-refresh"
+      "all-bank-refresh", "per-bank-refresh",
+      "open-row", "close-row"
     };
 
     inline static const ImplLUT m_request_translations = LUT (
       m_requests, m_commands, {
         {"read16", "RD16"}, {"write16", "WR16"}, 
         {"all-bank-refresh", "REFab"}, {"per-bank-refresh", "REFpb"},
+        {"open-row", "ACT-1"},
+        {"close-row", "PRE"},
       }
     );
-
    
   /************************************************
    *                   Timing


### PR DESCRIPTION
### Description
Currently, running Ramulator2 with the `LPDDR5` DRAM model and `ClosedRowPolicy` causes a crash (out-of-range exception/segfault). 

This happens because the memory controller attempts to look up the `"close-row"` request via `m_dram->m_requests("close-row")`, but both `"open-row"` and `"close-row"` are missing from the `LPDDR5`'s `m_requests` definition and `m_request_translations` table. As a result, the simulator cannot translate the policy's close-row request into a physical command.

### Changes Made
- Added `"open-row"` and `"close-row"` to the `m_requests` list in the `LPDDR5` class.
- Added the corresponding command mappings to `m_request_translations`:
  - `"open-row"` -> `"ACT-1"`
  - `"close-row"` -> `"PRE"`

### Testing
- [x] Compiled successfully.
- [x] Verified that the simulation now runs successfully without crashing when `ClosedRowPolicy` is configured in the YAML file.