### PR TITLE
Fix hardcoded row ID check in LPDDR5 RD16/WR16 pre-requisites

### DIFF
--- a/src/dram/impl/LPDDR5.cpp
+++ b/src/dram/impl/LPDDR5.cpp
@@ -460,7 +460,8 @@ class LPDDR5 : public IDRAM, public Implementation {
           case m_states["Closed"]: return m_commands["ACT-1"];
           case m_states["Pre-Opened"]: return m_commands["ACT-2"];
           case m_states["Opened"]: {
-            if (node->m_row_state.find(0) != node->m_row_state.end()) {
+            int target_row = addr_vec[LPDDR5::m_levels["row"]];
+            if (node->m_row_state.find(target_row) != node->m_row_state.end()) {
               Node* rank = node->m_parent_node->m_parent_node;
               if (rank->m_final_synced_cycle < clk) {
                 return m_commands["CASRD"];
@@ -482,7 +483,8 @@ class LPDDR5 : public IDRAM, public Implementation {
           case m_states["Closed"]: return m_commands["ACT-1"];
           case m_states["Pre-Opened"]: return m_commands["ACT-2"];
           case m_states["Opened"]: {
-            if (node->m_row_state.find(0) != node->m_row_state.end()) {
+            int target_row = addr_vec[LPDDR5::m_levels["row"]];
+            if (node->m_row_state.find(target_row) != node->m_row_state.end()) {
               Node* rank = node->m_parent_node->m_parent_node;
               if (rank->m_final_synced_cycle < clk) {
                 return m_commands["CASWR"];


### PR DESCRIPTION
**Describe the bug**
In the LPDDR5 implementation, the pre-requisite checks for the `RD16` and `WR16` commands incorrectly hardcode the row ID to `0` when checking if the target row is open in the bank's `m_row_state`. 

Specifically, the code uses:
`if (node->m_row_state.find(0) != node->m_row_state.end())`

This causes almost all accesses to rows other than Row 0 to fail the row-buffer hit check. As a result, the controller triggers unnecessary `PRE` and `ACT` commands, which severely impacts simulation accuracy, latency, and performance metrics.

**To Reproduce**
Run any trace or workload using the LPDDR5 model that accesses rows other than Row 0. You will observe an abnormally high number of precharge and activate commands due to artificial row-buffer misses.

**Expected behavior**
The model should extract the actual target row from the request's `addr_vec` and check if that specific row is currently open in the bank.

**Proposed Changes**
* Retrieved the target row using `int target_row = addr_vec[LPDDR5::m_levels["row"]];`.
* Replaced the hardcoded `find(0)` with `find(target_row)` in both the `RD16` and `WR16` pre-requisite lambdas.