### PR TITLE
Fix missing include for std::find_if

### DIFF
--- a/src/ramulator/frontend/impl/processor/simpleO3/llc.cpp
+++ b/src/ramulator/frontend/impl/processor/simpleO3/llc.cpp
@@ -1,6 +1,7 @@
 #include "ramulator/frontend/impl/processor/simpleO3/llc.h"
 
 #include <cassert>
+#include <algorithm>
 #include <fstream>
 
 namespace Ramulator {


### PR DESCRIPTION
Fix compilation error: ‘find_if’ is not a member of ‘std’; did you mean ‘find’?

GCC version: 14