### PR TITLE
fix: self-assignment in CountingBloomFilter and tick ordering in Hist…

### DIFF
--- a/src/dram_controller/impl/plugin/blockhammer/blockhammer_util.h
+++ b/src/dram_controller/impl/plugin/blockhammer/blockhammer_util.h
@@ -7,7 +7,6 @@
 namespace Ramulator {
 
 typedef std::function<uint32_t(uint32_t)> bloom_hash_fn;
-
 template <typename elem_t>
 struct HistoryEntry {
   elem_t entry;
@@ -30,7 +29,7 @@ public:
       // Initializers looks ugly here, opting for manual assignment
       this->m_num_counters = num_counters;
       this->m_ctr_thresh = ctr_thresh;
-      this->m_saturate = m_saturate;
+      this->m_saturate = saturate;
       m_counters.resize(m_num_counters);
       reset();
   }
@@ -154,8 +153,8 @@ public:
   }
 
   void update() {
-    m_tick++;
     elem_t elem = history[m_tick % m_size].entry;
+            m_tick++;
     if (!exists(elem)) {
       return;
     }


### PR DESCRIPTION
Fixes two bugs in `blockhammer_util.h` (related to issue #45).

**Bug 1 — Self-assignment in `CountingBloomFilter` constructor**

```cpp
// Before (broken):
this->m_saturate = m_saturate;  // assigns member to itself, ignores parameter

// After (fixed):
this->m_saturate = saturate;
```

The constructor parameter is named `saturate` but the assignment wrote `m_saturate = m_saturate`, which is a no-op self-assignment. The member is never initialised from the config value, so saturation is always effectively disabled regardless of the `bf_ctr_saturate` setting.

**Bug 2 — Off-by-one slot read in `HistoryBuffer::update()`**

```cpp
// Before (broken):
void update() {
    m_tick++;
    elem_t elem = history[m_tick % m_size].entry;  // reads slot AFTER increment

// After (fixed):
void update() {
    elem_t elem = history[m_tick % m_size].entry;  // reads the expiring slot first
    m_tick++;
```

`insert()` writes to `history[m_tick % m_size]`. `update()` is supposed to decrement the counter for the oldest entry before it is overwritten. But because `m_tick` was incremented before the read, `update()` always reads the *next* slot (the one that was just written by `insert()` at the new tick) instead of the entry actually expiring. This causes the wrong `elem_counter` entry to be decremented, leaving stale entries in the map and corrupting frequency counts.