### PR TITLE
Register GDDR6 model in src/dram/CMakeLists.txt

### DIFF
--- a/src/dram/CMakeLists.txt
+++ b/src/dram/CMakeLists.txt
@@ -14,6 +14,7 @@ target_sources(
   impl/DDR5-VRR.cpp
   impl/DDR5-RVRR.cpp
   impl/LPDDR5.cpp
+  impl/GDDR6.cpp
   impl/HBM.cpp
   impl/HBM2.cpp
   impl/HBM3.cpp


### PR DESCRIPTION
impl/GDDR6.cpp exists in the tree but is missing from the dram target_sources, so a config with DRAM: { impl: GDDR6 } fails at startup with 'implementation "GDDR6" ... is not registered'. Add the one missing source line so GDDR6 is compiled in and self-registers like the other memory types. No other changes.