### PR TITLE
fix(HBM2/HBM3): initialize nREFISB from tREFISB_TABLE (not tRFC_TABLE)

### DIFF
--- a/src/dram/impl/HBM2.cpp
+++ b/src/dram/impl/HBM2.cpp
@@ -249,7 +249,7 @@ class HBM2 : public IDRAM, public Implementation {
         { 160,  260,  350,  450},
       };
 
-      // tRFC table (unit is nanosecond!)
+      // tREFISB table (unit is nanosecond!)
       constexpr int tREFISB_TABLE[1][4] = {
       //  2Gb    4Gb    8Gb    16Gb
         { 4875,  4875,  2438,  2438},
@@ -265,8 +265,8 @@ class HBM2 : public IDRAM, public Implementation {
         }
       }(m_organization.density);
 
-      m_timing_vals("nRFC")  = JEDEC_rounding(tRFC_TABLE[0][density_id], tCK_ps);
-      m_timing_vals("nREFISB")  = JEDEC_rounding(tRFC_TABLE[0][density_id], tCK_ps);
+      m_timing_vals("nRFC")     = JEDEC_rounding(tRFC_TABLE[0][density_id], tCK_ps);
+      m_timing_vals("nREFISB")  = JEDEC_rounding(tREFISB_TABLE[0][density_id], tCK_ps);
 
       // Overwrite timing parameters with any user-provided value
       // Rate and tCK should not be overwritten

--- a/src/dram/impl/HBM3.cpp
+++ b/src/dram/impl/HBM3.cpp
@@ -254,7 +254,7 @@ class HBM3 : public IDRAM, public Implementation {
         { 160,  260,  350,  450},
       };
 
-      // tRFC table (unit is nanosecond!)
+      // tREFISB table (unit is nanosecond!)
       constexpr int tREFISB_TABLE[1][4] = {
       //  2Gb    4Gb    8Gb    16Gb
         { 4875,  4875,  2438,  2438},
@@ -270,8 +270,8 @@ class HBM3 : public IDRAM, public Implementation {
         }
       }(m_organization.density);
 
-      m_timing_vals("nRFC")  = JEDEC_rounding(tRFC_TABLE[0][density_id], tCK_ps);
-      m_timing_vals("nREFISB")  = JEDEC_rounding(tRFC_TABLE[0][density_id], tCK_ps);
+      m_timing_vals("nRFC")     = JEDEC_rounding(tRFC_TABLE[0][density_id], tCK_ps);
+      m_timing_vals("nREFISB")  = JEDEC_rounding(tREFISB_TABLE[0][density_id], tCK_ps);
 
       // Overwrite timing parameters with any user-provided value
       // Rate and tCK should not be overwritten


### PR DESCRIPTION
## Summary

In `src/dram/impl/HBM2.cpp` and `src/dram/impl/HBM3.cpp` the
`tREFISB_TABLE` constexpr is defined but never used. Instead `nREFISB`
is initialized from `tRFC_TABLE` — the same source used to populate
`nRFC` on the line above. This looks like a copy/paste oversight from
when the two tables were introduced.

```cpp
// HBM3.cpp (and identical structure in HBM2.cpp)
m_timing_vals("nRFC")    = JEDEC_rounding(tRFC_TABLE[0][density_id], tCK_ps);
m_timing_vals("nREFISB") = JEDEC_rounding(tRFC_TABLE[0][density_id], tCK_ps);
//                                        ^^^^^^^^^^ should be tREFISB_TABLE
```

`tRFC_TABLE` values are 160–450 ns; `tREFISB_TABLE` values are
2438–4875 ns. Using the former for `nREFISB` makes the *interval*
between per-bank refresh commands equal to the all-bank refresh *busy
time*, which schedules per-bank refreshes back-to-back and significantly
reduces achievable bandwidth for any controller / refresh manager that
uses `nREFISB` to pace `REFsb`/`RFMsb` commands.

This may be one contributor to the low HBM3 bandwidth reported in
**issue #42** (`/cc Mo-guan, 312hzeng, abhishektyaagi`), although that
issue likely has additional contributing factors (HBM2 nBL constraint
discussed in #104, address mapping with pseudochannels, etc.) so this
fix should not be assumed to close it on its own.

## Change

In both `HBM2.cpp` and `HBM3.cpp`:

- `nREFISB` is now initialized from `tREFISB_TABLE` instead of
  `tRFC_TABLE`.
- The comment `// tRFC table (unit is nanosecond!)` above
  `tREFISB_TABLE` is corrected to `// tREFISB table (unit is nanosecond!)`.
- Minor whitespace alignment between the two adjacent assignments.

Diff is intentionally minimal: 3 line-changes per file, 2 files.

## Test

- Project rebuilds cleanly with the existing CMake flow.
- `ramulator2 -f example_config.yaml` (DDR4_2400R baseline) produces
  identical statistics to before the change (no HBM code path
  exercised, sanity check).
- I do not yet have a regression test that exercises per-bank refresh
  on HBM3; happy to add one if the maintainers suggest where it should
  live.

## Risk

- Behavior change is intentional: any benchmark that relies on the
  previous (incorrect) `nREFISB` will see different timing.
- The change touches only refresh interval initialization and does not
  affect the `tRFC` busy time, command-to-command latency tables, or
  any controller / scheduler logic.
