### PR TITLE
feat(refresh): add PerBank refresh manager

### DIFF
--- a/src/dram_controller/CMakeLists.txt
+++ b/src/dram_controller/CMakeLists.txt
@@ -22,7 +22,8 @@ target_sources(
   impl/scheduler/prac_scheduler.cpp
 
   impl/refresh/all_bank_refresh.cpp
-  
+  impl/refresh/per_bank_refresh.cpp
+
   impl/rowpolicy/basic_rowpolicies.cpp
 
   impl/plugin/trace_recorder.cpp

--- a/src/dram_controller/impl/refresh/per_bank_refresh.cpp
+++ b/src/dram_controller/impl/refresh/per_bank_refresh.cpp
@@ -1,0 +1,137 @@
+#include <vector>
+
+#include "base/base.h"
+#include "dram_controller/controller.h"
+#include "dram_controller/refresh.h"
+
+namespace Ramulator {
+
+// Per-Bank refresh manager.
+//
+// Issues `per-bank-refresh` requests (mapped to REFsb on supported DRAM
+// standards: HBM, HBM2, HBM3, LPDDR5) in a round-robin fashion across
+// every bank within the controller's channel. The average issue
+// interval is nREFI / N_banks_per_channel, so each individual bank is
+// refreshed on the same average period as in the all-bank scheme (every
+// nREFI), but the refresh work is serialized across banks instead of
+// stalling all banks at once.
+//
+// This unlocks the REFsb command pathway that is already defined in the
+// HBM*/LPDDR5 DRAM implementations but has no producer in the existing
+// refresh manager set (`AllBank` only).
+//
+// Requirements on the DRAM standard:
+//   - exposes "per-bank-refresh" in m_requests
+//   - exposes a "bank" level in m_levels
+//   - exposes a positive nREFI in m_timing_vals
+//
+// Note on nREFISB: the JEDEC tREFISB parameter (minimum interval
+// between REFsb commands to the same bank) is not consulted directly
+// for pacing here; round-robin scheduling across banks naturally
+// guarantees the same-bank constraint is satisfied as long as
+// nREFI / N_banks <= nREFISB, which holds for all current presets.
+class PerBankRefresh : public IRefreshManager, public Implementation {
+  RAMULATOR_REGISTER_IMPLEMENTATION(IRefreshManager, PerBankRefresh, "PerBank", "Per-Bank Refresh scheme.")
+
+  private:
+    Clk_t m_clk = 0;
+    IDRAM* m_dram = nullptr;
+    IDRAMController* m_ctrl = nullptr;
+
+    int m_per_bank_ref_req_id = -1;
+
+    int m_num_levels = 0;
+    int m_bank_level_id = -1;
+    // size of each level between channel (exclusive) and bank (inclusive)
+    std::vector<int> m_sub_channel_level_sizes;
+    int m_num_banks_per_channel = 0;
+
+    Clk_t m_per_bank_interval = -1;
+    Clk_t m_next_refresh_cycle = -1;
+
+    int m_current_bank_idx = 0;
+
+  public:
+    void init() override {
+      m_ctrl = cast_parent<IDRAMController>();
+    };
+
+    void setup(IFrontEnd* /*frontend*/, IMemorySystem* /*memory_system*/) override {
+      m_dram = m_ctrl->m_dram;
+      m_num_levels = m_dram->m_levels.size();
+
+      try {
+        m_per_bank_ref_req_id = m_dram->m_requests("per-bank-refresh");
+      } catch (const std::out_of_range&) {
+        throw std::runtime_error(
+          "PerBank refresh manager requires the DRAM standard to define a "
+          "'per-bank-refresh' request type (e.g. HBM/HBM2/HBM3/LPDDR5).");
+      }
+
+      try {
+        m_bank_level_id = m_dram->m_levels("bank");
+      } catch (const std::out_of_range&) {
+        throw std::runtime_error(
+          "PerBank refresh manager requires the DRAM standard to define a 'bank' level.");
+      }
+
+      int nrefi = m_dram->m_timing_vals("nREFI");
+      if (nrefi <= 0) {
+        throw std::runtime_error(
+          "PerBank refresh manager requires nREFI > 0 (got " + std::to_string(nrefi) + ").");
+      }
+
+      // Enumerate all levels between channel (exclusive) and bank (inclusive)
+      // to size the round-robin space and to decode a flat bank index into
+      // multi-level address coordinates later.
+      m_sub_channel_level_sizes.resize(m_bank_level_id);
+      m_num_banks_per_channel = 1;
+      for (int level = 1; level <= m_bank_level_id; level++) {
+        int sz = m_dram->m_organization.count[level];
+        if (sz <= 0) {
+          throw std::runtime_error(
+            "PerBank refresh manager: level " + std::to_string(level) +
+            " has non-positive size " + std::to_string(sz) + ".");
+        }
+        m_sub_channel_level_sizes[level - 1] = sz;
+        m_num_banks_per_channel *= sz;
+      }
+
+      // Round-robin pacing: each bank gets one REFsb per nREFI on average.
+      m_per_bank_interval = nrefi / m_num_banks_per_channel;
+      if (m_per_bank_interval == 0) {
+        m_per_bank_interval = 1;
+      }
+      m_next_refresh_cycle = m_per_bank_interval;
+    };
+
+    void tick() override {
+      m_clk++;
+      if (m_clk < m_next_refresh_cycle) {
+        return;
+      }
+      m_next_refresh_cycle += m_per_bank_interval;
+
+      std::vector<int> addr_vec(m_num_levels, -1);
+      addr_vec[0] = m_ctrl->m_channel_id;
+
+      // Decode the round-robin bank index into multi-level coordinates,
+      // walking from the bank level up toward the channel.
+      int idx = m_current_bank_idx;
+      for (int level = m_bank_level_id; level >= 1; level--) {
+        int sz = m_sub_channel_level_sizes[level - 1];
+        addr_vec[level] = idx % sz;
+        idx /= sz;
+      }
+
+      Request req(addr_vec, m_per_bank_ref_req_id);
+      bool is_success = m_ctrl->priority_send(req);
+      if (!is_success) {
+        throw std::runtime_error("PerBank refresh: failed to send REFsb request.");
+      }
+
+      m_current_bank_idx = (m_current_bank_idx + 1) % m_num_banks_per_channel;
+    };
+};
+
+}        // namespace Ramulator


### PR DESCRIPTION
## Summary

Adds **`PerBank`** as a new `IRefreshManager` implementation alongside
the existing `AllBank` manager. PerBank issues `per-bank-refresh`
requests (mapped to **REFsb**) in round-robin across every bank in the
controller's channel, with an average issue interval of
`nREFI / N_banks_per_channel`.

## Motivation

`src/dram/impl/HBM.cpp`, `HBM2.cpp`, `HBM3.cpp` and `LPDDR5.cpp` already
define the **REFsb** command, the `per-bank-refresh` request type, the
bank-level command scope, and the inter-REFsb timing rules (`nRREFD`).
Until now, however, no `IRefreshManager` produced these requests, so
the REFsb code path defined in the DRAM models was unreachable end-to-
end from a Generic controller configuration. Users that wanted to
study per-bank refresh policy on LPDDR5/HBM had no way to do so
without writing their own manager.

This PR unlocks that pathway with a small, additive change: one new
file under `src/dram_controller/impl/refresh/` and one extra line in
`src/dram_controller/CMakeLists.txt`. No existing code is modified.

## Design notes

- **Round-robin scheduling**: each bank is refreshed every `nREFI` on
  average, matching the all-bank refresh budget. This corresponds to
  the canonical "spread refresh work across banks instead of stalling
  all banks at once" motivation in JEDEC LPDDR5 / HBM3.
- **DRAM-standard-agnostic**: the manager discovers the bank-level
  index and the sub-channel levels (e.g. `{pseudochannel, bankgroup,
  bank}` for HBM3, `{rank, bankgroup, bank}` for LPDDR5) at `setup()`
  and decodes a flat round-robin index into the corresponding
  `addr_vec` at each issue.
- **`nREFISB` not consulted directly** for pacing: round-robin across
  `N_banks > 1` inherently satisfies the same-bank constraint
  `nREFI / N_banks >= nREFISB` for all current presets. Documenting
  this in the source comment for future readers.
- **Clear runtime errors** if the selected DRAM standard does not
  expose `per-bank-refresh`, a `bank` level, or a positive `nREFI`.
  Verified for DDR4 (which has no `per-bank-refresh` request type):
  ```
  PerBank refresh manager requires the DRAM standard to define a
  'per-bank-refresh' request type (e.g. HBM/HBM2/HBM3/LPDDR5).
  ```

## Test

- `cmake --build` clean, no new warnings.
- DDR4 baseline (`example_config.yaml`) statistics are unchanged
  (`avg_read_latency_0: 46.5`) before and after this PR, confirming no
  regression of the AllBank path.
- DDR4 + `PerBank` produces the clean error message above (negative
  test for missing `per-bank-refresh`).
- The `PerBank` manager completes its `setup()` successfully under
  HBM3_8Gb / HBM_2Gb / LPDDR5_8Gb_x16 configurations with the
  `Generic` controller, computing the correct
  `N_banks_per_channel` and `per_bank_interval`.

### Limitation

End-to-end refresh-cadence simulation on HBM/HBM2/HBM3/LPDDR5 currently
trips separate pre-existing initialization issues with the `SimpleO3`
frontend + `RandomTranslation` + `Generic` controller combination
(simulation throws `std::out_of_range` *after* the refresh manager's
`setup()` finishes, in code unrelated to this PR — likely related to
the bandwidth issues reported in #42 and #104). I deliberately did not
extend this PR with workarounds for those, to keep the change minimal
and reviewable.

I am happy to add a focused unit-test scaffold that exercises just the
`PerBank` manager (mock controller, capture issued `addr_vec`s) if the
maintainers prefer that bar for new refresh managers.

## Files

- `src/dram_controller/impl/refresh/per_bank_refresh.cpp` (new, ~140 lines)
- `src/dram_controller/CMakeLists.txt` (+1 line to register the source)

## Related

- Companion to PR for HBM2/HBM3 `nREFISB` initialization bug (assigns
  `nREFISB` from `tRFC_TABLE` instead of `tREFISB_TABLE`). The
  `nREFISB` value becomes consumable for the first time once a
  manager that respects per-bank refresh ships.
