### PR TITLE
fix(rowpolicy): make ClosedRowPolicy work with rank-less DRAM (HBM family)

### DIFF
--- a/src/dram_controller/impl/rowpolicy/basic_rowpolicies.cpp
+++ b/src/dram_controller/impl/rowpolicy/basic_rowpolicies.cpp
@@ -53,14 +53,29 @@ class ClosedRowPolicy : public IRowPolicy, public Implementation {
 
       m_cap = param<int>("cap").default_val(10000000); // TODO
 
-      m_rank_level = m_dram->m_levels("rank");
+      // For DRAM standards without a "rank" level (e.g. the HBM family,
+      // which uses "pseudochannel" as the top-level sub-channel division),
+      // fall back to "pseudochannel". This keeps the flat-bank-id
+      // calculation below structurally correct (m_num_ranks is just the
+      // number of top-level sub-channel divisions per controller).
+      try {
+        m_rank_level = m_dram->m_levels("rank");
+        m_num_ranks = m_dram->get_level_size("rank");
+      } catch (const std::out_of_range&) {
+        try {
+          m_rank_level = m_dram->m_levels("pseudochannel");
+          m_num_ranks = m_dram->get_level_size("pseudochannel");
+        } catch (const std::out_of_range&) {
+          throw std::runtime_error(
+            "ClosedRowPolicy requires a 'rank' or 'pseudochannel' level in the DRAM hierarchy.");
+        }
+      }
       m_bankgroup_level = m_dram->m_levels("bankgroup");
       m_bank_level = m_dram->m_levels("bank");
       m_row_level = m_dram->m_levels("row");
 
       m_PRE_req_id = m_dram->m_requests("close-row");
 
-      m_num_ranks = m_dram->get_level_size("rank");
       m_num_bankgroups = m_dram->get_level_size("bankgroup");
       m_num_banks = m_dram->get_level_size("bank");
       


### PR DESCRIPTION
## Summary

`ClosedRowPolicy::setup()` unconditionally looks up the `"rank"` level,
which throws `std::out_of_range` at simulation start whenever the
selected DRAM standard does not expose a `rank` level. In practice
this means **ClosedRowPolicy cannot be used with HBM, HBM2, or HBM3**
— all of which use `pseudochannel` as the top-level sub-channel
division instead of `rank`.

This PR makes the policy fall back to `pseudochannel` when `rank` is
absent, with a clear error message if neither level exists.

## Reproducer

Any HBM3 (or HBM2 / HBM) Generic-controller config that selects
`ClosedRowPolicy` crashes immediately:

```yaml
DRAM:
  impl: HBM3
  org:    { preset: HBM3_8Gb, channel: 1 }
  timing: { preset: HBM3_2Gbps }
Controller:
  impl: Generic
  RowPolicy:
    impl: ClosedRowPolicy
```

```
$ ramulator2 -f hbm3.yaml
terminate called after throwing an instance of 'std::out_of_range'
  what():  unordered_map::at
```

The crash is unrelated to the controller or the workload — it is the
policy's `m_dram->m_levels("rank")` lookup at line 56.

## Fix

The flat-bank-id arithmetic in `ClosedRowPolicy::update()`
(`bank + bg * num_banks + rank * num_banks * num_bankgroups`) does not
require the top-level dimension to be named `rank`; it only requires
its size to be the number of top-level sub-channel divisions per
controller. Falling back to `pseudochannel` for HBM-family standards
preserves that semantic.

```cpp
try {
  m_rank_level = m_dram->m_levels("rank");
  m_num_ranks  = m_dram->get_level_size("rank");
} catch (const std::out_of_range&) {
  try {
    m_rank_level = m_dram->m_levels("pseudochannel");
    m_num_ranks  = m_dram->get_level_size("pseudochannel");
  } catch (const std::out_of_range&) {
    throw std::runtime_error(
      "ClosedRowPolicy requires a 'rank' or 'pseudochannel' level in the DRAM hierarchy.");
  }
}
```

`OpenRowPolicy` is not affected (it has an empty `setup()`).

## Test

- DDR4 baseline (`example_config.yaml`) still produces
  `avg_read_latency_0: 46.5`, `num_read_reqs_0: 6` — bit-identical to
  pre-change behavior, confirming the DDR code path is unchanged.
- Targeted negative path: a hypothetical DRAM with neither `rank` nor
  `pseudochannel` now produces a clean error instead of an
  unannotated `std::out_of_range`.

## Out of scope

`AllBankRefresh::setup()` also hardcodes `"rank"` and remains
incompatible with the HBM family. That is a more nuanced semantic
question — REFab's *command* scope is `"channel"` on HBM, so a naive
rank→pseudochannel substitution there would issue twice as many
REFabs as JEDEC specifies. Addressing it cleanly is left to a
follow-up PR.

## Related

This unblocks `Generic` controller use of HBM-family standards with
the `PerBank` refresh manager (which has no rank dependency). Once
that and this PR land, the configuration
`HBM3 + Generic + PerBank + ClosedRow` runs end-to-end for the first
time.
