### PR TITLE
plugin/scheduler: throw on error paths instead of exit(0)

### DIFF
--- a/src/dram_controller/impl/plugin/blockhammer/blockhammer.cpp
+++ b/src/dram_controller/impl/plugin/blockhammer/blockhammer.cpp
@@ -128,8 +128,9 @@ class BlockHammer : public IControllerPlugin, public Implementation, public IBlo
       m_bf_hist_size = tDelay / ((float) m_dram->m_timing_vals("tCK_ps") / 1000.0f);
 
       if (m_bf_hist_size < 0) {
-        std::cout << "[Ramulator::BlockHammerPlugin] Row History Buffer size must be positive." << std::endl;
-        exit(0);
+        throw std::runtime_error(
+          "[Ramulator::BlockHammerPlugin] Row History Buffer size must be positive (got " +
+          std::to_string(m_bf_hist_size) + ").");
       }
 
       auto* hash_functions = new std::vector<bloom_hash_fn>();

--- a/src/dram_controller/impl/plugin/prac/prac.cpp
+++ b/src/dram_controller/impl/plugin/prac/prac.cpp
@@ -214,8 +214,9 @@ private:
             };
             for (auto& h : handlers) {
                 if (!dram->m_commands.contains(h.cmd_name)) {
-                    std::cout << "[PRAC] Command " << h.cmd_name << "does not exist." << std::endl;
-                    exit(0);
+                    throw std::runtime_error(
+                        "[PRAC] Command " + h.cmd_name +
+                        " does not exist on the configured DRAM standard.");
                 }
                 m_handlertable[dram->m_commands(h.cmd_name)] = h;
             }

--- a/src/dram_controller/impl/plugin/rfm_manager.cpp
+++ b/src/dram_controller/impl/plugin/rfm_manager.cpp
@@ -44,8 +44,8 @@ public:
         m_ctrl = cast_parent<IDRAMController>();
         m_dram = m_ctrl->m_dram;
         if (!m_dram->m_requests.contains("rfm")) {
-            std::cout << "[Ramulator::RFMManager] [CRITICAL ERROR] DRAM Device does not support request: rfm" << std::endl; 
-            exit(0);
+            throw std::runtime_error(
+                "[Ramulator::RFMManager] DRAM device does not support request 'rfm'.");
         }
         m_rfm_req_id = m_dram->m_requests("rfm");
 
@@ -116,8 +116,8 @@ public:
         rfm.addr_vec[m_bank_level] = -1;
         // TODO: Add a buffer to retry later
         if (!m_ctrl->priority_send(rfm)) {
-            std::cout << "[Ramulator::RFMManager] [CRITICAL ERROR] Could not send request: rfm" << std::endl; 
-            exit(0);
+            throw std::runtime_error(
+                "[Ramulator::RFMManager] Could not send 'rfm' request to the controller.");
         }
         s_rfm_counter++;
     }

--- a/src/dram_controller/impl/prac_dram_controller.cpp
+++ b/src/dram_controller/impl/prac_dram_controller.cpp
@@ -70,8 +70,8 @@ public:
         // TODO: Just create it manually / get rid of the plugin and inject it here.
         m_prac = get_plugin<IPRAC>();
         if (!m_prac) {
-            std::cout << "[PRACCTRL] Need PRAC plugin!";
-            std::exit(0);
+            throw std::runtime_error(
+                "[PRACCTRL] PRAC controller requires the PRAC plugin to be enabled.");
         }
     };
 

--- a/src/dram_controller/impl/scheduler/blocking_scheduler.cpp
+++ b/src/dram_controller/impl/scheduler/blocking_scheduler.cpp
@@ -29,8 +29,8 @@ class BlockingScheduler : public IBHScheduler, public Implementation {
       m_dram = cast_parent<IBHDRAMController>()->m_dram;
       m_bh = cast_parent<IBHDRAMController>()->get_plugin<IBlockHammer>();
       if (!m_bh) {
-        std::cout << "BlockHammer scheduler requires BlockHammer plugin enabled!" << std::endl;
-        std::exit(0); 
+        throw std::runtime_error(
+          "BlockHammer scheduler requires the BlockHammer plugin to be enabled.");
       }
     }
 


### PR DESCRIPTION
## Summary

Six error sites under the controller/plugin/scheduler tree do:

```cpp
std::cout << "[CRITICAL ERROR] ..." << std::endl;
std::exit(0);
```

`exit(0)` returns success to the OS, so the surrounding harness — make,
CTest, CI, the SST integration, anything that branches on the process
exit code — reports the run as PASSED even though setup failed and no
useful simulation happened. It also bypasses every RAII destructor and
skips any stat dumping the surrounding code may have queued.

Replace each site with `throw std::runtime_error(...)`, matching the
pattern already used by `AllBankRefresh` (and the two refresh managers
proposed in #124 / #125). The diagnostic text is preserved and lightly
cleaned up so users still see the same message — but it now arrives via
the existing main-loop exception handler, and the process exits non-zero.

## Affected sites

| File | Message |
|---|---|
| `prac_dram_controller.cpp` | `[PRACCTRL] Need PRAC plugin!` |
| `plugin/prac/prac.cpp` | `[PRAC] Command X does not exist.` |
| `plugin/rfm_manager.cpp` (×2) | `DRAM Device does not support request: rfm` / `Could not send request: rfm` |
| `scheduler/blocking_scheduler.cpp` | `BlockHammer scheduler requires BlockHammer plugin enabled!` |
| `plugin/blockhammer/blockhammer.cpp` | `Row History Buffer size must be positive.` |

5 files, 6 call sites, +14 / -12 lines.

## Test

- `cmake --build` clean.
- `example_config.yaml` (DDR4 baseline) `avg_read_latency_0 = 46.5`,
  bit-identical to the pre-change run.
- `example_config_prac.yaml` (DDR5-VRR + PRAC + RFM) runs end-to-end
  and reports `prac_num_recovery = 21`, confirming the PRAC error
  sites are not reachable on the normal path and that I have not
  accidentally turned a runtime fast-path into a throw.

## Related

Companion to my #124/#125/#126 series on refresh managers + rowpolicy
robustness. The `throw` style aligns the PRAC/RFM/BlockHammer error
paths with the convention I followed in those PRs and that
`AllBankRefresh` already uses on the same path.
