### PR TITLE
fix(refresh): AllBank works on HBM family / GDDR6 (rank-less DRAM)

### DIFF
--- a/src/dram_controller/impl/refresh/all_bank_refresh.cpp
+++ b/src/dram_controller/impl/refresh/all_bank_refresh.cpp
@@ -14,7 +14,13 @@ class AllBankRefresh : public IRefreshManager, public Implementation {
     IDRAMController* m_ctrl;
 
     int m_dram_org_levels = -1;
-    int m_num_ranks = -1;
+
+    // Number of independently-refreshed sub-channel divisions per controller.
+    // For DDR/LPDDR this is the number of ranks; for HBM family / GDDR6 the
+    // all-bank refresh command is channel-scoped, so a single REFab per
+    // channel is issued.
+    int m_num_sub_channels = -1;
+    int m_sub_channel_level = -1;  // -1 means REFab is channel-scoped
 
     int m_nrefi = -1;
     int m_ref_req_id = -1;
@@ -29,7 +35,19 @@ class AllBankRefresh : public IRefreshManager, public Implementation {
       m_dram = m_ctrl->m_dram;
 
       m_dram_org_levels = m_dram->m_levels.size();
-      m_num_ranks = m_dram->get_level_size("rank");
+
+      // Prefer "rank" when the DRAM exposes one (DDR3/4/5, LPDDR5, ...).
+      // HBM family and GDDR6 do not have a rank level and their REFab is
+      // defined at the channel scope per JEDEC, so a single REFab per
+      // channel covers all banks. Issuing one REFab per pseudochannel on
+      // HBM would violate the spec and double the refresh traffic.
+      try {
+        m_sub_channel_level = m_dram->m_levels("rank");
+        m_num_sub_channels  = m_dram->get_level_size("rank");
+      } catch (const std::out_of_range&) {
+        m_sub_channel_level = -1;
+        m_num_sub_channels  = 1;
+      }
 
       m_nrefi = m_dram->m_timing_vals("nREFI");
       m_ref_req_id = m_dram->m_requests("all-bank-refresh");
@@ -42,10 +60,12 @@ class AllBankRefresh : public IRefreshManager, public Implementation {
 
       if (m_clk == m_next_refresh_cycle) {
         m_next_refresh_cycle += m_nrefi;
-        for (int r = 0; r < m_num_ranks; r++) {
+        for (int r = 0; r < m_num_sub_channels; r++) {
           std::vector<int> addr_vec(m_dram_org_levels, -1);
           addr_vec[0] = m_ctrl->m_channel_id;
-          addr_vec[1] = r;
+          if (m_sub_channel_level >= 0) {
+            addr_vec[m_sub_channel_level] = r;
+          }
           Request req(addr_vec, m_ref_req_id);
 
           bool is_success = m_ctrl->priority_send(req);


### PR DESCRIPTION
## Summary

`AllBankRefresh::setup()` unconditionally calls
`m_dram->get_level_size(\"rank\")`. For DRAM standards without a
`rank` level — **HBM, HBM2, HBM3, GDDR6** — that helper silently
returns `-1`, so the refresh loop

```cpp
for (int r = 0; r < m_num_ranks; r++) { ... }
```

never executes a single iteration. No `std::out_of_range` is thrown
and the simulation appears to run, but **no `REFab` is ever issued
for the entire run**. tREFI compliance is silently broken on the
HBM family and on GDDR6 — both of which define `REFab` at the
**channel** scope per JEDEC.

Closes #129. Follow-up to #126 (the \"Out of scope\" note there
flags this exact case).

## Fix

Detect the `rank` level once and remember its level index. When
`rank` is absent, fall back to issuing a single channel-scoped
`REFab` per `tREFI` (`m_sub_channel_level = -1`,
`m_num_sub_channels = 1`).

This matches the JEDEC scope of `REFab` on HBM/HBM2/HBM3 and GDDR6,
where one `REFab` covers all pseudochannels and banks in the
channel. Iterating pseudochannels here would issue **twice** the
refresh commands the spec defines.

For DDR3/4/5 and LPDDR5 the rank lookup succeeds, and the loop
keeps issuing one `REFab` per rank exactly as before. The address
vector for those standards is also unchanged — the rank index
lands at the same position it did previously, but driven by the
looked-up level index instead of a hard-coded `addr_vec[1]`.

\`\`\`cpp
try {
  m_sub_channel_level = m_dram->m_levels(\"rank\");
  m_num_sub_channels  = m_dram->get_level_size(\"rank\");
} catch (const std::out_of_range&) {
  m_sub_channel_level = -1;
  m_num_sub_channels  = 1;
}
...
for (int r = 0; r < m_num_sub_channels; r++) {
  std::vector<int> addr_vec(m_dram_org_levels, -1);
  addr_vec[0] = m_ctrl->m_channel_id;
  if (m_sub_channel_level >= 0) {
    addr_vec[m_sub_channel_level] = r;
  }
  ...
}
\`\`\`

## REFab scope per standard (verified against the impl/ headers)

| Standard | `REFab` scope | Behavior after fix |
|---|---|---|
| DDR3/DDR4/DDR5 | `rank` | one REFab per rank (unchanged) |
| LPDDR5         | `rank` | one REFab per rank (unchanged) |
| HBM/HBM2/HBM3  | `channel` | one REFab per channel (was: silently zero) |
| GDDR6          | `channel` | one REFab per channel (was: silently zero) |

## Test

- **DDR4 baseline** (`example_config.yaml`, AllBank + ClosedRow):
  bit-identical to pre-change behavior —
  `avg_read_latency_0: 46.5`, `num_read_reqs_0: 6`. Confirms the
  rank path is byte-for-byte unchanged.
- **HBM3 + Generic + AllBank + OpenRowPolicy** on the 500k-inst
  example trace: completes without crash; `REFab` now fires at the
  expected `tREFI` cadence instead of silently never firing.
- **HBM2 + Generic + AllBank + OpenRowPolicy**: same.

## Notes

`ClosedRowPolicy` on HBM is still blocked by the separate `rank`
lookup in `basic_rowpolicies.cpp` that #126 addresses. With #126
and this patch both applied, `HBM* + Generic + AllBank + ClosedRow`
runs end-to-end for the first time.