### PR TITLE
fix(LPDDR5): RD16/WR16 prerequisite checks the actual row index (closes #128)

### DIFF
--- a/src/dram/impl/LPDDR5.cpp
+++ b/src/dram/impl/LPDDR5.cpp
@@ -460,7 +460,7 @@ class LPDDR5 : public IDRAM, public Implementation {
           case m_states["Closed"]: return m_commands["ACT-1"];
           case m_states["Pre-Opened"]: return m_commands["ACT-2"];
           case m_states["Opened"]: {
-            if (node->m_row_state.find(0) != node->m_row_state.end()) {
+            if (node->m_row_state.find(addr_vec[m_levels["row"]]) != node->m_row_state.end()) {
               Node* rank = node->m_parent_node->m_parent_node;
               if (rank->m_final_synced_cycle < clk) {
                 return m_commands["CASRD"];
@@ -482,7 +482,7 @@ class LPDDR5 : public IDRAM, public Implementation {
           case m_states["Closed"]: return m_commands["ACT-1"];
           case m_states["Pre-Opened"]: return m_commands["ACT-2"];
           case m_states["Opened"]: {
-            if (node->m_row_state.find(0) != node->m_row_state.end()) {
+            if (node->m_row_state.find(addr_vec[m_levels["row"]]) != node->m_row_state.end()) {
               Node* rank = node->m_parent_node->m_parent_node;
               if (rank->m_final_synced_cycle < clk) {
                 return m_commands["CASWR"];


### PR DESCRIPTION
## Summary

The LPDDR5 bank-level preq lambdas for `RD16` and `WR16` look up
the wrong key in `m_row_state` when the bank is already in the
`Opened` state:

\`\`\`cpp
if (node->m_row_state.find(0) != node->m_row_state.end()) {
\`\`\`

The literal `0` here is the row index being searched for, not a
\"row id 0 means is-any-row-open\" sentinel. `m_row_state` is
populated by the `ACT-1` action as

\`\`\`cpp
node->m_row_state[target_id] = m_states[\"Pre-Opened\"];
\`\`\`

where `target_id` is the actual row index. So `find(0)` only ever
succeeds when the access happens to target row index 0.

For any access to a non-zero row the lambda falls into the else
branch and returns `PRE`. The controller issues `PRE`, the bank
returns to `Closed`, the next preq check sees `Closed` and
returns `ACT-1`, the bank goes `Pre-Opened` -> `Opened`, the
preq check hits the same hard-coded `find(0)` and returns `PRE`
again, and so on. **No `RD16`/`WR16` ever becomes ready, reads
never complete, and banks are never returned to the `Closed`
state.**

## Why this manifests as #128

This is silently catastrophic with `AllBank` refresh:

- `REFab` is queued every `tREFI`.
- `RequireAllBanksClosed` always returns `PREA` because banks are
  cycling `Closed` -> `Pre-Opened` -> `Opened` -> `Closed` -> ...
  forever and never settle in `Closed`.
- So `REFab` is never actually issued either.
- The priority buffer fills to its 1568-entry cap and the next
  refresh attempt throws \`\"Failed to send refresh!\"\`.

That's the exact symptom @pbirchxtx reported in #128 with
LPDDR5 + AllBank + OpenRow under SST.

The reason `ClosedRowPolicy` doesn't trip the same bug is that the
controller closes the bank after every access via `RDA`/`WRA`, so
the preq lambda hits the `Closed` case (which is correct) instead
of the `Opened` case (which is broken).

## Fix

Use the same pattern that `Bank::RequireRowOpen` in
`src/dram/lambdas/preq.h` uses for every other standard
(DDR3/4/5, HBM, GDDR6, ...):

\`\`\`cpp
node->m_row_state.find(addr_vec[m_levels[\"row\"]])
\`\`\`

This asks the only question that's actually meaningful here:
\"is the row this `RD16`/`WR16` is targeting the one currently
open in the bank?\" Same change applied symmetrically to the
`WR16` preq.

\`+2 / -2\` lines total.

## Test

- **DDR4 baseline** (`example_config.yaml`, AllBank +
  ClosedRow): bit-identical pre/post —
  `avg_read_latency_0: 46.5`, `num_read_reqs_0: 6`,
  `memory_system_cycles: 81306`. The change is confined to
  `LPDDR5.cpp` so no other standard is affected.
- **#128 reproducer** (LPDDR5_32Gb_x16 / LPDDR5_6400 /
  AllBank / OpenRow on the example trace): completes in
  `memory_system_cycles: 81309` with `num_read_reqs_0: 6`,
  instead of running indefinitely past 50M cycles and aborting
  with \`\"Failed to send refresh!\"\`.

## Note

The same lambda body has `if (rank->m_final_synced_cycle < clk)`
selecting between `CASRD` and just returning `cmd`. That branch
is unrelated to the row-index lookup and is left as-is.