### PR TITLE
fix(examples): drop removed scope= argument from AllBank refresh

### DIFF
--- a/examples/example_config.py
+++ b/examples/example_config.py
@@ -16,7 +16,7 @@ ddr4 = ramulator.dram.DDR4(org_preset="DDR4_8Gb_x8", timing_preset="DDR4_2400R",
 ctrl = ramulator.controller.GenericDDR(
     dram=ddr4,
     scheduler=ramulator.scheduler.FRFCFS(),
-    refresh_manager=ramulator.refresh_manager.AllBank(scope="Rank"),
+    refresh_manager=ramulator.refresh_manager.AllBank(),
     row_policy=ramulator.row_policy.Open(),
     addr_mapper=ramulator.addr_mapper.RoBaRaCoCh(),
 )

--- a/examples/gem5_se_ramulator_hello_world.py
+++ b/examples/gem5_se_ramulator_hello_world.py
@@ -23,7 +23,7 @@ ddr4 = ramulator.dram.DDR4(org_preset="DDR4_8Gb_x8", timing_preset="DDR4_2400R",
 ctrl = ramulator.controller.GenericDDR(
     dram=ddr4,
     scheduler=ramulator.scheduler.FRFCFS(),
-    refresh_manager=ramulator.refresh_manager.AllBank(scope="Rank"),
+    refresh_manager=ramulator.refresh_manager.AllBank(),
     row_policy=ramulator.row_policy.Open(),
     addr_mapper=ramulator.addr_mapper.RoBaRaCoCh(),
 )


### PR DESCRIPTION
## Summary

Both example scripts in \`examples/\` still pass \`scope=\"Rank\"\` to
\`ramulator.refresh_manager.AllBank(...)\`. The \`scope\` parameter was
removed in 278f1ef (\"Improved AllBankRefresh scope resolution\") when
AllBank switched to auto-resolving the scope from the DRAM standard,
so the refresh manager now raises:

\`\`\`
ValueError: AllBank: unknown parameters ['scope']
\`\`\`

at **script import**, which means a fresh \`python3 examples/example_config.py\`
fails before any simulation can start. The \"Your First Run\" section
of the README points users at exactly this script.

\`examples/gem5_se_ramulator_hello_world.py\` has the same line.
\`python/ramulator/gem5.py\` and every \`README.md\` snippet already
use the new \`AllBank()\` form, so the two example files are the only
remaining stale references.

## Fix

Drop the stale argument from both examples.

The new behavior (AllBank uses the standard-specific scope: \`Rank\`
for DDR/LPDDR, \`Channel\` for HBM1/GDDR6, \`PseudoChannel\` for
HBM2/3/4) is the right default for the configs both examples use
(DDR4 → Rank), so the simulation results don't change from what
the examples used to produce when the scope argument was still
honored.

## Test

\`\`\`
\$ python3 examples/example_config.py
Controller cycles:     81302
Avg read latency:      45.2 cycles
Read requests:         6
Write requests:        0
Row hits:              3
Row misses:            3
Row conflicts:         0
\`\`\`