### PR TITLE
fix(hbm3): add missing RFMpb -> RFMpb tRREFD timing constraint

### DIFF
--- a/python/ramulator/dram/hbm3.py
+++ b/python/ramulator/dram/hbm3.py
@@ -114,6 +114,7 @@ class HBM3(DRAMStandard):
         TimingConstraint(level="PseudoChannel", preceding=["WRA"], following=["RFMab"], latency="nCWL + nBL + nWR + nRP"),
         TimingConstraint(level="PseudoChannel", preceding=["RFMab"], following=["ACT", "PREab"], latency="nRFMab"),
         # RFMpb constraints (same structure as REFpb)
+        TimingConstraint(level="PseudoChannel", preceding=["RFMpb"], following=["RFMpb"], latency="nRREFD"),
         TimingConstraint(level="PseudoChannel", preceding=["RFMpb"], following=["ACT"], latency="nRREFD"),
         TimingConstraint(level="PseudoChannel", preceding=["ACT"], following=["RFMpb"], latency="nRRDS"),
 


### PR DESCRIPTION
## Summary

\`HBM3.timing_constraints\` declares the RFMpb constraints with the
comment \"RFMpb constraints (same structure as REFpb)\", but the
\`RFMpb -> RFMpb\` back-to-back \`tRREFD\` edge is missing.

\`\`\`python
# python/ramulator/dram/hbm3.py — current

# REFpb (complete — 3 edges)
TimingConstraint(level=\"PseudoChannel\", preceding=[\"REFpb\"], following=[\"REFpb\"], latency=\"nRREFD\"),
TimingConstraint(level=\"PseudoChannel\", preceding=[\"REFpb\"], following=[\"ACT\"],   latency=\"nRREFD\"),
TimingConstraint(level=\"PseudoChannel\", preceding=[\"ACT\"],   following=[\"REFpb\"], latency=\"nRRDS\"),

# RFMpb \"same structure as REFpb\" — but missing the self-edge
TimingConstraint(level=\"PseudoChannel\", preceding=[\"RFMpb\"], following=[\"ACT\"],   latency=\"nRREFD\"),
TimingConstraint(level=\"PseudoChannel\", preceding=[\"ACT\"],   following=[\"RFMpb\"], latency=\"nRRDS\"),
\`\`\`

HBM4 declares the symmetric \`RFMpb -> RFMpb\` constraint at
\`python/ramulator/dram/hbm4.py:84\`, so HBM3 is diverging from both
its own stated intent (per the inline comment) and the sibling
HBM4 standard.

## Why this matters

Per JEDEC JESD238 HBM3, RFMpb is functionally a per-bank
refresh-management command and is bound by \`tRREFD\` against any
preceding per-bank refresh-class command on the same pseudo-channel,
just like REFpb. Without this constraint, back-to-back RFMpb pairs
scheduled to different banks in the same pseudo-channel can be
issued tighter than \`tRREFD\` apart in simulation — i.e. silently
faster than the spec allows. This is the same class of issue as a
missing REFpb -> REFpb edge would be; the bug just hadn't been
exercised because no in-tree refresh manager issues RFMpb yet.

## Fix

Add the missing constraint so RFMpb now mirrors REFpb at the
\`PseudoChannel\` level:

\`\`\`
PseudoChannel: preceding=[RFMpb] following=[RFMpb]  latency=nRREFD   (new)
PseudoChannel: preceding=[RFMpb] following=[ACT]    latency=nRREFD
PseudoChannel: preceding=[ACT]   following=[RFMpb]  latency=nRRDS
\`\`\`

\`+1 / -0\` line.

Only the Python source is touched. The auto-generated \`HBM3.cpp\`
boilerplate is unchanged because timing constraints are loaded at
runtime from the Python-side config (see
\`DRAMSpec::load_config\` in \`src/ramulator/dram/dram_spec.cpp\`),
not baked into the codegen output.

## Test

- \`tests/device_timings/test_hbm3.py\` — passes
- \`tests/controller_scheduling/HBMController/\` — 89 tests pass
  (includes \`test_hbm34_refresh.py\`)
- \`tests/smoke/\` — passes