### PR TITLE
fix(hbm3): add missing BankGroup-level ACT<->REFpb/RFMpb tRRDL edges

### DIFF
--- a/python/ramulator/dram/hbm3.py
+++ b/python/ramulator/dram/hbm3.py
@@ -133,6 +133,9 @@ class HBM3(DRAMStandard):
         TimingConstraint(level="BankGroup", preceding=["WR", "WRA"], following=["RD", "RDA"], latency="nCWL + nBL + nWTRL"),
         # Same-group RAS timing
         TimingConstraint(level="BankGroup", preceding=["ACT"], following=["ACT"], latency="nRRDL"),
+        # Same-group RAS-to-REFpb/RFMpb timing
+        TimingConstraint(level="BankGroup", preceding=["ACT"], following=["REFpb", "RFMpb"], latency="nRRDL"),
+        TimingConstraint(level="BankGroup", preceding=["REFpb", "RFMpb"], following=["ACT"], latency="nRRDL"),
 
         # ============================================================
         # Bank — single-bank timing


### PR DESCRIPTION
## Summary

HBM3 declares same-bank-group RAS timing for ACT but not for
REFpb / RFMpb at the \`BankGroup\` scope:

\`\`\`python
# python/ramulator/dram/hbm3.py:135 — current
TimingConstraint(level=\"BankGroup\", preceding=[\"ACT\"], following=[\"ACT\"], latency=\"nRRDL\"),
\`\`\`

HBM4 declares the symmetric constraint for both REFpb and RFMpb in
the same bank group (\`hbm4.py:99-100\`):

\`\`\`python
TimingConstraint(level=\"BankGroup\", preceding=[\"ACT\"], following=[\"REFpb\", \"RFMpb\"], latency=\"nRRDL\"),
TimingConstraint(level=\"BankGroup\", preceding=[\"REFpb\", \"RFMpb\"], following=[\"ACT\"], latency=\"nRRDL\"),
\`\`\`

So HBM3 is diverging from the sibling standard at the BankGroup
scope.

## Why this matters

The existing PseudoChannel-scope edges in HBM3:

\`\`\`
PseudoChannel: ACT     -> REFpb  (nRRDS)   # different-BG: short tRRD
PseudoChannel: ACT     -> RFMpb  (nRRDS)
PseudoChannel: REFpb   -> ACT    (nRREFD)
PseudoChannel: RFMpb   -> ACT    (nRREFD)
\`\`\`

only constrain **different-bank-group** activity (\`nRRDS\` is the
short tRRD). Per JEDEC JESD238, same-bank-group ACT and per-bank
refresh / refresh-management commands must respect \`tRRDL\` — the
long tRRD — which is strictly larger than \`tRRDS\` in every HBM3
speed grade. Without the same-group edge, an ACT in bank group X
followed by REFpb to a different bank in the same group X can be
issued \`tRRDS\` apart in simulation instead of \`tRRDL\`.

## Fix

Add two BankGroup-scope constraints matching HBM4:

\`\`\`
BankGroup: ACT             -> REFpb, RFMpb   latency=nRRDL
BankGroup: REFpb, RFMpb    -> ACT            latency=nRRDL
\`\`\`

\`+3 / -0\` lines (two new constraints + a comment).

Only the Python source is touched. Timing constraints are loaded
at runtime via \`DRAMSpec::load_config\`, so no codegen regen is
needed for this fix.

## Test

- \`tests/device_timings/test_hbm3.py\` — passes
- \`tests/controller_scheduling/HBMController/\` — 89 tests pass
- \`tests/smoke/\` — passes

## Related

Same class of constraint-completeness fix as #133 (HBM3 RFMpb
self-edge) and #134 (HBM1/HBM2 REFpb self-edge). Together these
PRs bring the HBM-family standards to parity on refresh/RFM
constraint coverage.