### PR TITLE
fix(hbm2): add missing BankGroup-level ACT<->REFpb tRRDL edges

### DIFF
--- a/python/ramulator/dram/hbm2.py
+++ b/python/ramulator/dram/hbm2.py
@@ -98,6 +98,9 @@ class HBM2(DRAMStandard):
         TimingConstraint(level="BankGroup", preceding=["WR", "WRA"], following=["RD", "RDA"], latency="nCWL + nBL + nWTRL"),
         # Same-group RAS timing
         TimingConstraint(level="BankGroup", preceding=["ACT"], following=["ACT"], latency="nRRDL"),
+        # Same-group RAS-to-REFpb timing
+        TimingConstraint(level="BankGroup", preceding=["ACT"], following=["REFpb"], latency="nRRDL"),
+        TimingConstraint(level="BankGroup", preceding=["REFpb"], following=["ACT"], latency="nRRDL"),
 
         # ============================================================
         # Bank — single-bank timing


### PR DESCRIPTION
## Summary

HBM2 declares same-bank-group RAS timing for ACT but not for REFpb
at the \`BankGroup\` scope:

\`\`\`python
# python/ramulator/dram/hbm2.py:100 — current
TimingConstraint(level=\"BankGroup\", preceding=[\"ACT\"], following=[\"ACT\"], latency=\"nRRDL\"),
\`\`\`

HBM4 declares the symmetric constraint for REFpb in the same bank
group (\`hbm4.py:99-100\`), and the analogous gap in HBM3 is
addressed in the sibling PR. HBM2 was diverging from the HBM4
reference at the BankGroup scope.

## Why this matters

The existing PseudoChannel-scope edges in HBM2:

\`\`\`
PseudoChannel: ACT     -> REFpb  (nRRDS)
PseudoChannel: REFpb   -> ACT    (nRREFD)
\`\`\`

only constrain **different-bank-group** activity (\`nRRDS\` is the
short tRRD). Per JEDEC JESD235 HBM2, same-bank-group ACT and
per-bank refresh commands must respect \`tRRDL\` — the long tRRD —
which is strictly larger than \`tRRDS\` in every HBM2 speed grade.
Without the same-group edge, an ACT in bank-group X followed by
REFpb to a different bank in the same group X can be issued
\`tRRDS\` apart in simulation instead of \`tRRDL\`.

HBM2 does not have RFM commands, so this fix is REFpb-only —
unlike the HBM3 sibling PR which adds the same edges for both
REFpb and RFMpb.

## Fix

Add two BankGroup-scope constraints matching HBM4:

\`\`\`
BankGroup: ACT     -> REFpb   latency=nRRDL
BankGroup: REFpb   -> ACT     latency=nRRDL
\`\`\`

\`+3 / -0\` lines (two new constraints + a comment).

Only the Python source is touched. Timing constraints are loaded
at runtime via \`DRAMSpec::load_config\`, so no codegen regen is
needed for this fix.

## Test

- All 167 tests pass (\`tests/\` full run, 183 s)

## Related

Same class of constraint-completeness fix as #133, #134, #135.
Together these PRs bring the HBM-family standards to parity on
refresh / RFM constraint coverage at all scopes.