### PR TITLE
fix(hbm1): add missing BankGroup-level ACT<->REFpb tRRDL edges

### DIFF
--- a/python/ramulator/dram/hbm1.py
+++ b/python/ramulator/dram/hbm1.py
@@ -89,6 +89,9 @@ class HBM1(DRAMStandard):
         TimingConstraint(level="BankGroup", preceding=["WR", "WRA"], following=["RD", "RDA"], latency="nCWL + nBL + nWTRL"),
         # BankGroup — same-group RAS timing
         TimingConstraint(level="BankGroup", preceding=["ACT"], following=["ACT"], latency="nRRDL"),
+        # BankGroup — same-group RAS-to-REFpb timing
+        TimingConstraint(level="BankGroup", preceding=["ACT"], following=["REFpb"], latency="nRRDL"),
+        TimingConstraint(level="BankGroup", preceding=["REFpb"], following=["ACT"], latency="nRRDL"),
 
         # Bank — single-bank timing
         TimingConstraint(level="Bank", preceding=["ACT"], following=["ACT"], latency="nRC"),


### PR DESCRIPTION
## Summary

Completes the BankGroup-scope refresh-constraint coverage for the
HBM family. Same gap pattern as #135 (HBM3) and #136 (HBM2):

\`\`\`python
# python/ramulator/dram/hbm1.py:91 — current
TimingConstraint(level=\"BankGroup\", preceding=[\"ACT\"], following=[\"ACT\"], latency=\"nRRDL\"),
\`\`\`

HBM4 declares the symmetric REFpb edges at the BankGroup scope, so
HBM1 was the third HBM-family standard with this gap.

## Why this matters

The existing Channel-scope edges in HBM1:

\`\`\`
Channel: ACT     -> REFpb  (nRRDS)
Channel: REFpb   -> ACT    (nRREFD)
\`\`\`

only constrain **different-bank-group** activity (\`nRRDS\` is the
short tRRD). Per JEDEC JESD235 HBM, same-bank-group ACT and
per-bank refresh commands must respect \`tRRDL\` — the long tRRD —
which is strictly larger than \`tRRDS\` in HBM speed grades.
Without the same-group edge, an ACT in bank-group X followed by
REFpb to a different bank in the same group X can be issued
\`tRRDS\` apart in simulation instead of \`tRRDL\`.

HBM1 does not have RFM commands, so this fix is REFpb-only.

## Fix

Add two BankGroup-scope constraints matching HBM4 for REFpb:

\`\`\`
BankGroup: ACT     -> REFpb   latency=nRRDL
BankGroup: REFpb   -> ACT     latency=nRRDL
\`\`\`

\`+3 / -0\` lines.

Only the Python source is touched. Timing constraints are loaded
at runtime via \`DRAMSpec::load_config\`, so no codegen regen is
needed.

## Test

- \`tests/smoke\` — passes
- \`tests/controller_scheduling\` — 95 tests pass

## Related

Closes the HBM-family parity work started in #133, #134, #135,
#136. With this PR merged, HBM1/HBM2/HBM3/HBM4 all have the
complete set of REFpb (and where applicable RFMpb) constraints
at all relevant scopes.