### PR TITLE
docs(README): include Sid in HBM3/HBM4 hierarchy diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -1151,11 +1151,15 @@ The node tree represents the structural hierarchy of one channel. For DDR4, that
 Channel -> Rank -> BankGroup -> Bank
 ```
 
-For HBM3 it is:
+For HBM3 and HBM4 it is:
 
 ```text
-Channel -> PseudoChannel -> BankGroup -> Bank
+Channel -> PseudoChannel -> Sid -> BankGroup -> Bank
 ```
+
+(`Sid` models the stack-die identifier introduced for high-stack HBM3/HBM4
+parts. HBM1 omits both `PseudoChannel` and `Sid`; HBM2 has `PseudoChannel`
+but no `Sid`.)
 
 The tree stops before the `Row` level. Ramulator does not instantiate one node per physical row. Instead, it tracks row state lazily inside the bank-like node that owns those rows.
 


### PR DESCRIPTION
## Summary

The README section \"Hierarchical timing tree\" shows the HBM3
hierarchy as

\`\`\`text
Channel -> PseudoChannel -> BankGroup -> Bank
\`\`\`

but HBM3 (and HBM4) both include a \`Sid\` (stack-die identifier)
level — see \`python/ramulator/dram/hbm3.py\`:

\`\`\`python
levels = {
    \"Channel\":        \"N_A\",
    \"PseudoChannel\":  \"N_A\",
    \"Sid\":            \"N_A\",       # <-- missing from README
    \"BankGroup\":      \"N_A\",
    \"Bank\":           \"Closed\",
    ...
}
\`\`\`

HBM4 has the same \`Sid\` level. New readers using the README to:

- index into \`addr_vec[]\` for a custom controller plugin
- reason about which scope a timing constraint applies to
- understand the levels they'll see when writing tests

get a misleading picture. They'd expect \`addr_vec\` to be length 6
(Channel, PC, BG, Bank, Row, Column) when it's actually length 7
for HBM3/HBM4.

## Fix

Update the diagram to:

\`\`\`text
Channel -> PseudoChannel -> Sid -> BankGroup -> Bank
\`\`\`

and add a one-line note clarifying the family layout:

- HBM1 omits both \`PseudoChannel\` and \`Sid\`
- HBM2 has \`PseudoChannel\` but no \`Sid\`
- HBM3/HBM4 have both \`PseudoChannel\` and \`Sid\`

so readers can map the spec they're reading to the right
hierarchy without grepping the \`.py\` files.

Docs-only change. \`+6 / -2\` lines. No code or test changes.