### PR TITLE
fix(gddr6): block PREab during REFab refresh window

### DIFF
--- a/python/ramulator/dram/gddr6.py
+++ b/python/ramulator/dram/gddr6.py
@@ -111,7 +111,7 @@ class GDDR6(DRAMStandard):
 
         # REFab
         # Should block all commands for the duration of the refresh, but we only enforce the timing for ACT and PREab, since those are the most critical ones.
-        TimingConstraint(level="Channel", preceding=["REFab"], following=["ACT", "REFab"], latency="nRFCab"),
+        TimingConstraint(level="Channel", preceding=["REFab"], following=["ACT", "PREab", "REFab"], latency="nRFCab"),
 
         # Same Bank Group
         TimingConstraint(level="BankGroup", preceding=["RD", "RDA"], following=["RD", "RDA"], latency="nCCDL"),


### PR DESCRIPTION
## Summary

The inline comment on the REFab post-condition constraint says

\`\`\`python
# Should block all commands for the duration of the refresh, but we
# only enforce the timing for ACT and PREab, since those are the
# most critical ones.
\`\`\`

but the constraint itself only lists \`ACT\` and \`REFab\` in
\`following\`:

\`\`\`python
TimingConstraint(level=\"Channel\", preceding=[\"REFab\"],
                 following=[\"ACT\", \"REFab\"], latency=\"nRFCab\"),
\`\`\`

so \`PREab\` is silently allowed to issue immediately after \`REFab\`,
violating the documented intent and JEDEC JESD250 GDDR6, where the
device cannot service any row command — including \`PREab\` — until
\`tRFCab\` has elapsed after \`REFab\`.

## Why this matters

A scheduler can today issue \`REFab\` on cycle K and \`PREab\` on
cycle K+1 without any timing barrier between them. Once the
refresh state machine completes a full \`nRFCab\` window after the
actual \`REFab\`, the device tracking model will still believe an
unrelated \`PREab\` at K+1 was legal, and downstream timing
depending on the implied \"all banks closed\" state will start
mis-counting.

## Fix

Add \`PREab\` to the \`following\` list so the constraint matches the
comment and JEDEC behavior:

\`\`\`python
TimingConstraint(level=\"Channel\", preceding=[\"REFab\"],
                 following=[\"ACT\", \"PREab\", \"REFab\"],
                 latency=\"nRFCab\"),
\`\`\`

\`+1 / -1\` line. Python source only — timing constraints are loaded
at runtime via \`DRAMSpec::load_config\`, no codegen regen needed.

## Test

- \`tests/device_timings/test_gddr6.py\` — 6 tests pass
- \`tests/smoke\` — 9 tests pass