### PR TITLE
fix(hbm3): backfill REFpb/RFMpb edges that HBM4 has but HBM3 misses

### DIFF
--- a/python/ramulator/dram/hbm3.py
+++ b/python/ramulator/dram/hbm3.py
@@ -101,7 +101,7 @@ class HBM3(DRAMStandard):
         TimingConstraint(level="PseudoChannel", preceding=["PREpb", "PREab"], following=["REFab"], latency="nRP"),
         TimingConstraint(level="PseudoChannel", preceding=["RDA"], following=["REFab"], latency="nRP + nRTP"),
         TimingConstraint(level="PseudoChannel", preceding=["WRA"], following=["REFab"], latency="nCWL + nBL + nWR + nRP"),
-        TimingConstraint(level="PseudoChannel", preceding=["REFab"], following=["ACT", "PREab"], latency="nRFC"),
+        TimingConstraint(level="PseudoChannel", preceding=["REFab"], following=["ACT", "PREab", "REFpb"], latency="nRFC"),
         # REFpb-to-REFpb and REFpb-to-ACT different bank (tRREFD)
         TimingConstraint(level="PseudoChannel", preceding=["REFpb"], following=["REFpb"], latency="nRREFD"),
         TimingConstraint(level="PseudoChannel", preceding=["REFpb"], following=["ACT"], latency="nRREFD"),
@@ -112,7 +112,7 @@ class HBM3(DRAMStandard):
         TimingConstraint(level="PseudoChannel", preceding=["PREpb", "PREab"], following=["RFMab"], latency="nRP"),
         TimingConstraint(level="PseudoChannel", preceding=["RDA"], following=["RFMab"], latency="nRP + nRTP"),
         TimingConstraint(level="PseudoChannel", preceding=["WRA"], following=["RFMab"], latency="nCWL + nBL + nWR + nRP"),
-        TimingConstraint(level="PseudoChannel", preceding=["RFMab"], following=["ACT", "PREab"], latency="nRFMab"),
+        TimingConstraint(level="PseudoChannel", preceding=["RFMab"], following=["ACT", "PREab", "RFMpb"], latency="nRFMab"),
         # RFMpb constraints (same structure as REFpb)
         TimingConstraint(level="PseudoChannel", preceding=["RFMpb"], following=["ACT"], latency="nRREFD"),
         TimingConstraint(level="PseudoChannel", preceding=["ACT"], following=["RFMpb"], latency="nRRDS"),
@@ -144,8 +144,8 @@ class HBM3(DRAMStandard):
         TimingConstraint(level="Bank", preceding=["PREpb"], following=["ACT"], latency="nRP"),
         TimingConstraint(level="Bank", preceding=["RD"], following=["PREpb"], latency="nRTP"),
         TimingConstraint(level="Bank", preceding=["WR"], following=["PREpb"], latency="nCWL + nBL + nWR"),
-        TimingConstraint(level="Bank", preceding=["RDA"], following=["ACT"], latency="nRTP + nRP"),
-        TimingConstraint(level="Bank", preceding=["WRA"], following=["ACT"], latency="nCWL + nBL + nWR + nRP"),
+        TimingConstraint(level="Bank", preceding=["RDA"], following=["ACT", "REFpb", "RFMpb"], latency="nRTP + nRP"),
+        TimingConstraint(level="Bank", preceding=["WRA"], following=["ACT", "REFpb", "RFMpb"], latency="nCWL + nBL + nWR + nRP"),
 
         # Bank — per-bank refresh
         TimingConstraint(level="Bank", preceding=["REFpb"], following=["ACT"], latency="nRFCpb"),


### PR DESCRIPTION
## Summary

A direct diff of \`hbm3.py\` vs \`hbm4.py\` \`timing_constraints\`
surfaces three HBM3 edges where REFpb / RFMpb are silently allowed
to issue tighter than the corresponding HBM4 sibling constraint:

\`\`\`
# PseudoChannel
HBM3: REFab -> ACT, PREab          (nRFC)
HBM4: REFab -> ACT, PREab, REFpb   (nRFC)        # +REFpb

HBM3: RFMab -> ACT, PREab          (nRFMab)
HBM4: RFMab -> ACT, PREab, RFMpb   (nRFMab)      # +RFMpb

# Bank
HBM3: RDA  -> ACT                  (nRTP + nRP)
HBM4: RDA  -> ACT, REFpb, RFMpb    (nRTP + nRP)  # +REFpb,RFMpb

HBM3: WRA  -> ACT                  (... + nRP)
HBM4: WRA  -> ACT, REFpb, RFMpb    (... + nRP)   # +REFpb,RFMpb
\`\`\`

## Why this matters

Same JEDEC reasoning applies to both HBM3 and HBM4:

- After \`REFab\` (\`RFMab\`), the whole pseudo-channel is busy for
  \`nRFC\` (\`nRFMab\`). HBM4 explicitly says \`REFpb\` / \`RFMpb\` to
  the channel can't issue inside that window. HBM3 doesn't, so a
  scheduler is free to start a per-bank refresh immediately after
  an all-bank refresh — issuing two refresh waves back-to-back
  with no recovery time.

- After \`RDA\` / \`WRA\` on a bank, the bank must hold for the
  read or write to complete and precharge before any
  refresh-class command targets it again. HBM4 includes \`REFpb\` /
  \`RFMpb\` in the same constraint as \`ACT\`. HBM3 doesn't, so a
  per-bank refresh to the same bank can be scheduled tighter than
  the JEDEC RDA/WRA-to-REF window.

## Fix

Add \`REFpb\` (and \`RFMpb\` where applicable) to the \`following\`
lists so HBM3 matches HBM4:

\`\`\`
PseudoChannel:
  REFab -> ACT, PREab, REFpb   (was missing REFpb)
  RFMab -> ACT, PREab, RFMpb   (was missing RFMpb)

Bank:
  RDA -> ACT, REFpb, RFMpb     (was missing both)
  WRA -> ACT, REFpb, RFMpb     (was missing both)
\`\`\`

\`+4 / -4\` lines (four constraints, each extends its \`following\`
list).

Only the Python source is touched. Timing constraints are loaded
at runtime via \`DRAMSpec::load_config\`, so no codegen regen is
needed.

## Test

- All 167 tests pass (\`tests/\` full run, 183 s)

## Related

Same class of HBM-family parity audit as #133, #134, #135, #136,
#137. With this PR merged, HBM3 mirrors every HBM4 refresh / RFM
constraint at every applicable scope.