### PR TITLE
fix(hbm1,hbm2): add Bank-level RDA/WRA -> REFpb edges (HBM4 parity)

### DIFF
--- a/python/ramulator/dram/hbm1.py
+++ b/python/ramulator/dram/hbm1.py
@@ -98,8 +98,8 @@ class HBM1(DRAMStandard):
         TimingConstraint(level="Bank", preceding=["PREpb"], following=["ACT"], latency="nRP"),
         TimingConstraint(level="Bank", preceding=["RD"], following=["PREpb"], latency="nRTPL"),
         TimingConstraint(level="Bank", preceding=["WR"], following=["PREpb"], latency="nCWL + nBL + nWR"),
-        TimingConstraint(level="Bank", preceding=["RDA"], following=["ACT"], latency="nRTPL + nRP"),
-        TimingConstraint(level="Bank", preceding=["WRA"], following=["ACT"], latency="nCWL + nBL + nWR + nRP"),
+        TimingConstraint(level="Bank", preceding=["RDA"], following=["ACT", "REFpb"], latency="nRTPL + nRP"),
+        TimingConstraint(level="Bank", preceding=["WRA"], following=["ACT", "REFpb"], latency="nCWL + nBL + nWR + nRP"),
 
         # Bank — per-bank refresh (REFSB)
         TimingConstraint(level="Bank", preceding=["REFpb"], following=["ACT"], latency="nRFCpb"),

--- a/python/ramulator/dram/hbm2.py
+++ b/python/ramulator/dram/hbm2.py
@@ -109,8 +109,8 @@ class HBM2(DRAMStandard):
         TimingConstraint(level="Bank", preceding=["PREpb"], following=["ACT"], latency="nRP"),
         TimingConstraint(level="Bank", preceding=["RD"], following=["PREpb"], latency="nRTPL"),
         TimingConstraint(level="Bank", preceding=["WR"], following=["PREpb"], latency="nCWL + nBL + nWR"),
-        TimingConstraint(level="Bank", preceding=["RDA"], following=["ACT"], latency="nRTPL + nRP"),
-        TimingConstraint(level="Bank", preceding=["WRA"], following=["ACT"], latency="nCWL + nBL + nWR + nRP"),
+        TimingConstraint(level="Bank", preceding=["RDA"], following=["ACT", "REFpb"], latency="nRTPL + nRP"),
+        TimingConstraint(level="Bank", preceding=["WRA"], following=["ACT", "REFpb"], latency="nCWL + nBL + nWR + nRP"),
 
         # Bank — per-bank refresh (REFSB)
         TimingConstraint(level="Bank", preceding=["REFpb"], following=["ACT"], latency="nRFCpb"),


### PR DESCRIPTION
## Summary

HBM4 (\`hbm4.py:110-111\`) constrains Bank-level RDA/WRA against
REFpb in addition to ACT:

\`\`\`python
Bank: RDA -> ACT, REFpb, RFMpb   (nRTP + nRP)
Bank: WRA -> ACT, REFpb, RFMpb   (nCWL + nBL + nWR + nRP)
\`\`\`

HBM1 and HBM2 omit \`REFpb\` from these edges, so a per-bank
refresh to the same bank can be scheduled tighter than the JEDEC
RDA/WRA-to-refresh recovery window. The same gap was fixed for
HBM3 in the sibling PR #140 (HBM3 also adds \`RFMpb\` since HBM3
has RFM commands; HBM1/HBM2 only need \`REFpb\`).

## Why this matters

Per JEDEC JESD235 (HBM/HBM2), after an auto-precharge read
(\`RDA\`), a same-bank refresh-class command — \`REFab\` targeting
the bank or \`REFpb\` to the bank — must wait \`tRTPL + tRPpb\`.
After \`WRA\`, it must wait \`tCWL + tBL + tWR + tRPpb\`. The
existing constraints already encode this for \`ACT\`; this PR
extends the same window to \`REFpb\`.

## Fix

Extend the \`following\` list on RDA/WRA Bank-scope constraints
to include \`REFpb\`:

\`\`\`
Bank: RDA -> ACT, REFpb   (was: ACT only)
Bank: WRA -> ACT, REFpb   (was: ACT only)
\`\`\`

\`+2 / -2\` lines per file (HBM1 and HBM2). Python source only.

## Test

- \`tests/smoke\` — passes
- \`tests/controller_scheduling\` — 95 tests pass

## Related

Same audit pass as #140 (HBM3 vs HBM4 Bank-scope edges),
continuing the HBM-family parity work in #133-#137.