### PR TITLE
fix(lpddr5): add Bank-level RDA/WRA -> REFpb edges

### DIFF
--- a/python/ramulator/dram/lpddr5.py
+++ b/python/ramulator/dram/lpddr5.py
@@ -108,8 +108,8 @@ class LPDDR5(DRAMStandard):
         TimingConstraint(level="Bank", preceding=["PREpb"], following=["ACT1"], latency="nRP"),
         TimingConstraint(level="Bank", preceding=["RD"], following=["PREpb"], latency="nRTP"),
         TimingConstraint(level="Bank", preceding=["WR"], following=["PREpb"], latency="nCWL + nBL + nWR"),
-        TimingConstraint(level="Bank", preceding=["RDA"], following=["ACT1"], latency="nRTP + nRP"),
-        TimingConstraint(level="Bank", preceding=["WRA"], following=["ACT1"], latency="nCWL + nBL + nWR + nRP"),
+        TimingConstraint(level="Bank", preceding=["RDA"], following=["ACT1", "REFpb"], latency="nRTP + nRP"),
+        TimingConstraint(level="Bank", preceding=["WRA"], following=["ACT1", "REFpb"], latency="nCWL + nBL + nWR + nRP"),
 
         # Bank — per-bank refresh
         TimingConstraint(level="Bank", preceding=["REFpb"], following=["ACT1"], latency="nRFCpb"),


### PR DESCRIPTION
## Summary

Per JEDEC JESD209-5 (LPDDR5), after an auto-precharge read
(\`RDA\`) the bank cannot service a same-bank refresh-class
command — \`REFab\` targeting the bank or \`REFpb\` to the bank —
until the read pipeline has drained and the bank is precharged.
After \`WRA\` the same window applies with the write recovery
added.

The existing Bank-scope constraints already encode this for
\`ACT1\` (LPDDR5's first activate sub-command):

\`\`\`python
# python/ramulator/dram/lpddr5.py:111-112 — current
Bank: RDA -> ACT1   (nRTP + nRP)
Bank: WRA -> ACT1   (nCWL + nBL + nWR + nRP)
\`\`\`

but \`REFpb\` is not in either following list, so a per-bank
refresh to the same bank can be scheduled tighter than the JEDEC
RDA/WRA-to-refresh recovery window.

## Why this matters

HBM4 includes \`REFpb\` / \`RFMpb\` in the equivalent Bank-scope
constraint (\`hbm4.py:110-111\`), and the same gap was just patched
for HBM1/HBM2 (sibling PR #141) and HBM3 (#140). LPDDR5 has the
same shape — \`REFpb\` at the Bank scope with no constraint
protecting the post-RDA/WRA window.

## Fix

Extend the \`following\` list on the RDA/WRA Bank-scope
constraints to include \`REFpb\`:

\`\`\`
Bank: RDA -> ACT1, REFpb   (was: ACT1 only)
Bank: WRA -> ACT1, REFpb   (was: ACT1 only)
\`\`\`

\`+2 / -2\` lines. Python source only — timing constraints are
loaded at runtime via \`DRAMSpec::load_config\`.

LPDDR5 does not implement RFMpb, so the constraint extension is
REFpb-only (unlike HBM3/HBM4 which also include RFMpb).

## Test

- \`tests/smoke\` — passes
- \`tests/controller_scheduling\` — 95 tests pass

## Related

Continues the cross-standard refresh-constraint-completeness audit
in #133, #134, #135, #136, #137, #140, plus the sibling HBM1/HBM2
Bank-level fix #141.