### PR TITLE
fix(ddr3): block PREab during REFab refresh window (DDR4/DDR5 parity)

### DIFF
--- a/python/ramulator/dram/ddr3.py
+++ b/python/ramulator/dram/ddr3.py
@@ -63,7 +63,7 @@ class DDR3(DRAMStandard):
         TimingConstraint(level="Rank", preceding=["PREpb", "PREab"], following=["REFab"], latency="nRP"),
         TimingConstraint(level="Rank", preceding=["RDA"], following=["REFab"], latency="nRP + nRTP"),
         TimingConstraint(level="Rank", preceding=["WRA"], following=["REFab"], latency="nCWL + nBL + nWR + nRP"),
-        TimingConstraint(level="Rank", preceding=["REFab"], following=["ACT"], latency="nRFC"),
+        TimingConstraint(level="Rank", preceding=["REFab"], following=["ACT", "PREab"], latency="nRFC"),
 
         # Bank — single-bank timing
         TimingConstraint(level="Bank", preceding=["ACT"], following=["ACT"], latency="nRC"),


### PR DESCRIPTION
## Summary

DDR3 declares the post-REFab constraint as ACT-only:

\`\`\`python
# python/ramulator/dram/ddr3.py:66 — current
TimingConstraint(level=\"Rank\", preceding=[\"REFab\"], following=[\"ACT\"], latency=\"nRFC\"),
\`\`\`

but DDR4 and DDR5 both include \`PREab\` in the \`following\` list:

\`\`\`python
ddr4.py:67  preceding=[\"REFab\"] following=[\"ACT\", \"PREab\"]  latency=\"nRFC\"
ddr5.py:80  preceding=[\"REFab\"] following=[\"ACT\", \"PREab\"]  latency=\"nRFC\"
\`\`\`

so DDR3 is the only DDR-family standard that allows \`PREab\` to
issue immediately after \`REFab\`.

## Why this matters

Per JEDEC JESD79-3 (DDR3), the entire rank is in refresh state
for \`tRFC\` after \`REFab\` and no command — including \`PREab\` —
may be accepted in that window. A scheduler can today issue
\`REFab\` on cycle K and \`PREab\` on cycle K+1 without any timing
barrier between them, then have \`ACT\` blocked until K+tRFC by
the existing constraint — leaving the simulator in an
inconsistent state.

Same class of fix as the GDDR6 PREab-after-REFab missing edge
in #139: the standard's intent is \"block all commands during
refresh,\" but the constraint list under-specifies and only blocks
\`ACT\`.

## Fix

Add \`PREab\` to the \`following\` list so DDR3 matches DDR4/DDR5:

\`\`\`
Rank: REFab -> ACT, PREab   latency=nRFC  (was: ACT only)
\`\`\`

\`+1 / -1\` line. Python source only — timing constraints are
loaded at runtime via \`DRAMSpec::load_config\`, no codegen regen
needed.

## Test

- \`tests/smoke\` — passes
- \`tests/controller_scheduling\` — passes
- \`tests/device_timings\` — passes (149 total)

## Related

Same audit pattern as #133-#137 (HBM-family parity), #139 (GDDR6
PREab-after-REFab), #140-#142 (HBM3/HBM1/HBM2/LPDDR5 RDA/WRA
follow-list completeness).