### PR TITLE
fix(base): widen slice_lower_bits mask literal to Integral_t

### DIFF
--- a/src/ramulator/base/utils.h
+++ b/src/ramulator/base/utils.h
@@ -33,7 +33,13 @@ template <typename Integral_t>
 Integral_t slice_lower_bits(Integral_t& addr, int num_bits) {
   static_assert(std::is_integral_v<Integral_t>, "Only integral types are allowed for bitwise operations!");
 
-  Integral_t lbits = addr & ((1 << num_bits) - 1);
+  // The mask literal must be widened to Integral_t before shifting; the
+  // plain literal `1` is `int`, so `1 << num_bits` is undefined for
+  // num_bits >= 31 on platforms with 32-bit int, even when the destination
+  // is a 64-bit Addr_t. In current Ramulator configs num_bits stays small
+  // (per-level address bits), but the address mappers slice from Addr_t
+  // (int64_t) and a forward-compatible mask is essentially free.
+  Integral_t lbits = addr & ((static_cast<Integral_t>(1) << num_bits) - 1);
   addr >>= num_bits;
   return lbits;
 };


### PR DESCRIPTION
## Summary

\`slice_lower_bits\` builds its lower-bit mask as:

\`\`\`cpp
Integral_t lbits = addr & ((1 << num_bits) - 1);
\`\`\`

The literal \`1\` is \`int\`, so \`1 << num_bits\` has **undefined
behavior for \`num_bits >= 31\`** on platforms with 32-bit \`int\`,
even though the destination is a 64-bit \`Addr_t\`.

Today the address mappers call \`slice_lower_bits\` with
per-level bit counts that stay well under 31 (largest in-tree
level is ~17 bits for LPDDR5 rows), so the UB isn't triggered in
practice — but a future device preset with a wider single level
(e.g. a 1<<31 row count on a forward-looking HBM/DDR variant), or
a coarser channel-mapper field, would hit it silently. The mask
on a 32-bit-overflowing literal might roll over to a negative
number that, after implicit widening to \`int64_t\`, leaves the
mask all-1s above the intended bit window and clobbers neighbour
levels.

## Fix

Widen the mask literal explicitly:

\`\`\`cpp
Integral_t lbits = addr & ((static_cast<Integral_t>(1) << num_bits) - 1);
\`\`\`

For 64-bit \`Integral_t\` this lifts the safe ceiling on
\`num_bits\` from 30 to 62 and removes the UB for the 31/32-bit
cases.

No runtime change for any current call site — every existing
\`num_bits\` fits comfortably in \`int\`, so the generated mask
values are identical bit-for-bit.

The matching \`addr >>= num_bits\` is already correctly typed
(shift on \`Integral_t\`) and does not need a change.

## Test

- All 167 tests pass (\`tests/\` full run, 186 s)