### PR TITLE
fix(frontend): reject empty trace files instead of UB in get_next_inst

### DIFF
--- a/src/ramulator/frontend/impl/memory_trace/loadstore_trace.cpp
+++ b/src/ramulator/frontend/impl/memory_trace/loadstore_trace.cpp
@@ -104,6 +104,10 @@ class LoadStoreTrace : public IFrontEnd, public Implementation {
     trace_file.close();
 
     m_trace_length = m_trace.size();
+    if (m_trace_length == 0) {
+      throw std::runtime_error(
+          fmt::format("Trace {} produced no entries — file is empty", file_path_str));
+    }
   };
 
   bool is_finished() override {

--- a/src/ramulator/frontend/impl/memory_trace/readwrite_trace.cpp
+++ b/src/ramulator/frontend/impl/memory_trace/readwrite_trace.cpp
@@ -106,6 +106,10 @@ class ReadWriteTrace : public IFrontEnd, public Implementation {
     trace_file.close();
 
     m_trace_length = m_trace.size();
+    if (m_trace_length == 0) {
+      throw std::runtime_error(
+          fmt::format("Trace {} produced no entries — file is empty", file_path_str));
+    }
   };
 
   bool is_finished() override {

--- a/src/ramulator/frontend/impl/processor/simpleO3/core.cpp
+++ b/src/ramulator/frontend/impl/processor/simpleO3/core.cpp
@@ -46,6 +46,11 @@ SimpleO3Core::Trace::Trace(std::string file_path_str) {
 
   trace_file.close();
   m_trace_length = m_trace.size();
+  if (m_trace_length == 0) {
+    throw std::runtime_error(
+        fmt::format("Trace {} produced no instructions — file is empty or all lines were skipped",
+                    file_path_str));
+  }
 }
 
 const SimpleO3Core::Trace::Inst& SimpleO3Core::Trace::get_next_inst() {


### PR DESCRIPTION
## Summary

Three frontend trace parsers (\`SimpleO3\` core trace,
\`ReadWriteTrace\`, \`LoadStoreTrace\`) all end their constructors
with:

\`\`\`cpp
trace_file.close();
m_trace_length = m_trace.size();
\`\`\`

When the trace file is empty (or only contains lines that get
silently skipped), \`m_trace\` stays empty and
\`m_trace_length = 0\`. **No exception is raised at load time.**
The frontend then proceeds to call into the trace and immediately
hits two distinct C++ undefined-behavior cases:

1. \`SimpleO3Core::SimpleO3Core(...)\` calls
   \`m_trace.get_next_inst()\` in its ctor body, which does

   \`\`\`cpp
   const Inst& inst = m_trace[m_curr_trace_idx];   // [0] on empty vector — UB
   \`\`\`

2. \`get_next_inst\` (and the equivalent in \`ReadWriteTrace\` /
   \`LoadStoreTrace\` \`tick()\`) wraps the cursor with

   \`\`\`cpp
   m_curr_trace_idx = (m_curr_trace_idx + 1) % m_trace_length;
   \`\`\`

   **\`% 0\` is undefined behavior.**

In release builds with optimizations on, this typically manifests
as a silent garbage read followed by either a hang, a SIGFPE, or a
nonsensical \"simulation succeeded\" with 0 instructions retired,
depending on the platform and the surrounding allocator state.

## Fix

In every parser's constructor, after the file is closed and
\`m_trace_length\` is set, throw a \`std::runtime_error\` if the
trace contains zero entries:

\`\`\`cpp
if (m_trace_length == 0) {
  throw std::runtime_error(
    fmt::format(\"Trace {} produced no instructions — file is \"
                \"empty or all lines were skipped\", file_path_str));
}
\`\`\`

This fails loud at trace-load time with the offending path in the
error message, rather than letting the simulator march into UB.

The three parsers fix the same shape of bug; each diff is +4 to
+5 lines and only adds the check. No behavior change for any
non-empty trace.

## Test

- All 167 tests pass (\`tests/\` full run, 180 s) — every in-tree
  trace fixture is non-empty, so behavior is unchanged for valid
  input.