### PR TITLE
fix(frontend): LatencyThroughputTrace rejects nop_counter <= 0

### DIFF
--- a/src/ramulator/frontend/impl/memory_trace/latency_throughput_trace.cpp
+++ b/src/ramulator/frontend/impl/memory_trace/latency_throughput_trace.cpp
@@ -93,6 +93,14 @@ class LatencyThroughputTrace : public IFrontEnd, public Implementation {
           "LatencyThroughputTrace: num_streaming_requests must be set when streaming_only=true");
     }
 
+    // nop_counter <= 0 is silently catastrophic — tick_nop() does
+    //     m_curr_nop = (m_curr_nop + 1) % m_nop_counter;
+    // which is divide-by-zero (UB) for 0 and ill-defined for negatives.
+    if (m_nop_counter <= 0) {
+      throw std::runtime_error(fmt::format(
+          "LatencyThroughputTrace: nop_counter must be >= 1 (got {})", m_nop_counter));
+    }
+
     m_stats.add("streaming_requests_sent", s_streaming_sent);
     m_stats.add("probe_requests_completed", s_probes_completed);
     m_stats.add("total_probe_latency", s_total_probe_latency);


### PR DESCRIPTION
## Summary

\`tick_nop()\` advances the NOP cursor every tick with:

\`\`\`cpp
m_curr_nop = (m_curr_nop + 1) % m_nop_counter;
\`\`\`

If a user passes \`nop_counter = 0\` (typo, default-of-zero in a
script, etc.), this is **divide-by-zero — undefined behavior**.
Today it slips through \`init()\` because \`nop_counter\` is
\`required()\` but has no positivity check; the only similar
validation in \`init()\` is for
\`streaming_only && num_streaming_requests <= 0\`. Negative values
are equally ill-defined for \`%\` on signed integers in C++.

## Fix

Add a positivity check right next to the existing
\`streaming_only\`/\`num_streaming_requests\` check, with the
offending value in the error message:

\`\`\`cpp
if (m_nop_counter <= 0) {
  throw std::runtime_error(fmt::format(
    \"LatencyThroughputTrace: nop_counter must be >= 1 (got {})\",
    m_nop_counter));
}
\`\`\`

\`nop_counter = 1\` stays legal (always-fire stream, never
NOP-skip), matching the existing semantics of the
\`m_nop_counter > 1\` guard inside \`tick_nop\`.

## Test

- All 167 tests pass (\`tests/\` full run, 178 s) — every in-tree
  test config passes a positive \`nop_counter\`, so behavior is
  unchanged for valid input.

## Related

Same class of fail-loud-at-config-time hardening as #146
(\`parse_capacity_str\` silent zero) and #148 (empty trace UB).