### PR TITLE
fix(frontend): LatencyThroughputTrace validates all positive-integer params

### DIFF
--- a/src/ramulator/frontend/impl/memory_trace/latency_throughput_trace.cpp
+++ b/src/ramulator/frontend/impl/memory_trace/latency_throughput_trace.cpp
@@ -93,6 +93,32 @@ class LatencyThroughputTrace : public IFrontEnd, public Implementation {
           "LatencyThroughputTrace: num_streaming_requests must be set when streaming_only=true");
     }
 
+    // Numeric parameters that participate in `%` or `/` in address
+    // generation and bank decomposition. Zero or negative values are
+    // silently catastrophic — `streaming_addr_vec()` and
+    // `decompose_bank()` would either divide by zero (UB) or build a
+    // distribution with reversed bounds (also UB on
+    // std::uniform_int_distribution). Fail loud at init() instead.
+    auto require_positive = [&](const char* name, int value) {
+      if (value <= 0) {
+        throw std::runtime_error(fmt::format(
+            "LatencyThroughputTrace: {} must be >= 1 (got {})", name, value));
+      }
+    };
+    require_positive("total_bank_units", m_total_bank_units);
+    require_positive("num_rows", m_num_rows);
+    require_positive("num_cols", m_num_cols);
+    require_positive("internal_prefetch_size", m_internal_prefetch_size);
+    require_positive("num_cls", m_num_cls);
+    require_positive("stream_cls", m_stream_cls);
+    for (size_t i = 0; i < m_bank_counts.size(); i++) {
+      if (m_bank_counts[i] <= 0) {
+        throw std::runtime_error(fmt::format(
+            "LatencyThroughputTrace: bank_counts[{}] must be >= 1 (got {})",
+            i, m_bank_counts[i]));
+      }
+    }
+
     m_stats.add("streaming_requests_sent", s_streaming_sent);
     m_stats.add("probe_requests_completed", s_probes_completed);
     m_stats.add("total_probe_latency", s_total_probe_latency);


### PR DESCRIPTION
## Summary

Following the same hardening pattern as the existing
\`streaming_only\`/\`num_streaming_requests\` check and #149
(\`nop_counter\` must be \`>= 1\`), this PR adds positivity checks
for every other parameter that participates in \`%\` or \`/\` in
the address generation and bank decomposition code:

| Param | Where it would UB |
|---|---|
| \`total_bank_units\` | \`idx % m_total_bank_units\` |
| \`num_rows\` | \`(idx / ...) % m_num_rows\` |
| \`num_cols\` | \`cls_dist(0, m_num_cols - 1)\` upper bound |
| \`internal_prefetch_size\` | \`col / m_internal_prefetch_size\` |
| \`num_cls\` | \`cls_dist\` upper bound |
| \`stream_cls\` | \`idx % m_stream_cls\` |
| \`bank_counts[i]\` | \`flat % m_bank_counts[i]\` and \`uniform_int_distribution(0, m_bank_counts[i] - 1)\` |

All of these are \`required()\` parameters but had no positivity
check. A user typo (or default-of-zero in a generator script) that
sends any of them through as 0 or negative would either:

- divide by zero in \`%\` / \`/\` → undefined behavior
- construct \`std::uniform_int_distribution(0, -1)\` → also UB per
  \`[rand.dist.uni.int]/p2\` (\`b\` must be \`>= a\`)

The catastrophic case manifests as either a hang in the streaming
loop or a SIGFPE deep in
\`uniform_int_distribution::operator()\`, depending on platform
— neither of which points the user back at the offending config
field.

## Fix

Add a \`require_positive(name, value)\` local helper at the end
of \`init()\` and call it for each scalar parameter, plus an
indexed loop for \`m_bank_counts\`. Every error message names the
field and includes the rejected value:

\`\`\`
LatencyThroughputTrace: num_rows must be >= 1 (got 0)
LatencyThroughputTrace: bank_counts[2] must be >= 1 (got -1)
\`\`\`

Each check is essentially free at init() time, and no behavior
changes for valid input.

## Test

- All 167 tests pass (\`tests/\` full run, 178 s) — every in-tree
  test passes positive values, so behavior is unchanged.

## Related

Same fail-loud-at-config-time pattern as #146 (\`parse_capacity_str\`
silent zero), #148 (empty trace UB), #149 (\`nop_counter <= 0\` UB).