### PR TITLE
feat(hbm4): add HBM4_32Gb_12Hi org preset (12-stack height)

### DIFF
--- a/python/ramulator/dram/hbm4.py
+++ b/python/ramulator/dram/hbm4.py
@@ -173,6 +173,7 @@ class HBM4(DRAMStandard):
 HBM4.org_presets = {
     "HBM4_32Gb_4Hi":  {"density": 32768, "dq": 32, "channel_width": 32, "pseudochannel": 2, "sid": 1, "bankgroup": 2, "bank": 8, "row": 1<<14, "column": (1<<5) << 3},  # HBM CA already takes BL into account
     "HBM4_32Gb_8Hi":  {"density": 32768, "dq": 32, "channel_width": 32, "pseudochannel": 2, "sid": 2, "bankgroup": 2, "bank": 8, "row": 1<<14, "column": (1<<5) << 3},  # HBM CA already takes BL into account
+    "HBM4_32Gb_12Hi": {"density": 32768, "dq": 32, "channel_width": 32, "pseudochannel": 2, "sid": 3, "bankgroup": 2, "bank": 8, "row": 1<<14, "column": (1<<5) << 3},  # 12-Hi stack — sid=3 (SK hynix HBM4 product line)
     "HBM4_32Gb_16Hi": {"density": 32768, "dq": 32, "channel_width": 32, "pseudochannel": 2, "sid": 4, "bankgroup": 2, "bank": 8, "row": 1<<14, "column": (1<<5) << 3},  # HBM CA already takes BL into account
 }
 


### PR DESCRIPTION
## Summary

Adds the **12-Hi** stack option for the 32 Gb HBM4 die family.

## Before / after

\`\`\`python
# before
HBM4.org_presets = {
    \"HBM4_32Gb_4Hi\":  { ..., \"sid\": 1, ... },
    \"HBM4_32Gb_8Hi\":  { ..., \"sid\": 2, ... },
    \"HBM4_32Gb_16Hi\": { ..., \"sid\": 4, ... },
}
# 12-Hi (sid=3) is missing in the 4/8/16 sequence.

# after
HBM4.org_presets = {
    \"HBM4_32Gb_4Hi\":  { ..., \"sid\": 1, ... },
    \"HBM4_32Gb_8Hi\":  { ..., \"sid\": 2, ... },
    \"HBM4_32Gb_12Hi\": { ..., \"sid\": 3, ... },  # new
    \"HBM4_32Gb_16Hi\": { ..., \"sid\": 4, ... },
}
\`\`\`

## Why

**12-Hi is the SK hynix HBM4 product line's middle-tier stack**
(36 GB per package at 24 Gb DRAM dies, scaled here to 48 GB at
the v2.1 reference 32 Gb die). Without this preset, users
modeling a 12-Hi workload have to either drop down to 8-Hi
(under-stresses the channel) or jump to 16-Hi (over-stresses).

Same shape as the existing 4 / 8 / 16-Hi entries — only \`sid\`
differs, every other org field stays at the family default.

## Verification

\`\`\`
\$ python3 -c \"
  import ramulator
  for p in ['HBM4_32Gb_4Hi', 'HBM4_32Gb_8Hi',
            'HBM4_32Gb_12Hi', 'HBM4_32Gb_16Hi']:
      d = ramulator.dram.HBM4(org_preset=p,
                              timing_preset='HBM4_8000Mbps')
      print(p, d.to_config()['org'])
\"
HBM4_32Gb_4Hi  org: {'dq': 32, 'count': [1, 2, 1, 2, 8, 16384, 256]}
HBM4_32Gb_8Hi  org: {'dq': 32, 'count': [1, 2, 2, 2, 8, 16384, 256]}
HBM4_32Gb_12Hi org: {'dq': 32, 'count': [1, 2, 3, 2, 8, 16384, 256]}
HBM4_32Gb_16Hi org: {'dq': 32, 'count': [1, 2, 4, 2, 8, 16384, 256]}
\`\`\`

(\`count[2]\` is \`sid\`; the rest are identical, confirming the new
preset slots cleanly into the existing 4/8/16 sequence.)

## Test

- All 167 tests pass (\`tests/\` full run, 178 s)

## Related

Sits alongside my \`HBM4_9600Mbps\` / \`HBM4_12800Mbps\` timing
preset PRs — together those three give a clean speed × stack
matrix for HBM4 product modeling.