### PR TITLE
feat(hbm3): add 16Gb_12hi / 32Gb_12hi org presets (12-stack height)

### DIFF
--- a/python/ramulator/dram/hbm3.py
+++ b/python/ramulator/dram/hbm3.py
@@ -217,6 +217,10 @@ HBM3.org_presets = {
     "HBM3_16Gb_8hi": {"density": 16384, "dq": 32, "channel_width": 32, "pseudochannel": 2, "sid": 2, "bankgroup": 4, "bank": 4, "row": 1<<14, "column": (1<<5) << 3},  # HBM CA already takes BL into account
     # die density = 32 Gb, channel density = 16 Gb
     "HBM3_32Gb_8hi": {"density": 32768, "dq": 32, "channel_width": 32, "pseudochannel": 2, "sid": 2, "bankgroup": 4, "bank": 4, "row": 1<<15, "column": (1<<5) << 3},  # HBM CA already takes BL into account
+    # die density = 16 Gb, channel density = 12 Gb — 12-Hi stack (HBM3E gen-1 product line)
+    "HBM3_16Gb_12hi": {"density": 16384, "dq": 32, "channel_width": 32, "pseudochannel": 2, "sid": 3, "bankgroup": 4, "bank": 4, "row": 1<<14, "column": (1<<5) << 3},  # HBM CA already takes BL into account
+    # die density = 32 Gb, channel density = 12 Gb — 12-Hi stack (HBM3E gen-2/3 product line)
+    "HBM3_32Gb_12hi": {"density": 32768, "dq": 32, "channel_width": 32, "pseudochannel": 2, "sid": 3, "bankgroup": 4, "bank": 4, "row": 1<<15, "column": (1<<5) << 3},  # HBM CA already takes BL into account
     # die density = 32 Gb, channel density = 8 Gb
     "HBM3_32Gb_16hi": {"density": 32768, "dq": 32, "channel_width": 32, "pseudochannel": 2, "sid": 4, "bankgroup": 4, "bank": 4, "row": 1<<15, "column": (1<<5) << 3},  # HBM CA already takes BL into account
 }


### PR DESCRIPTION
## Summary

Adds **12-Hi stack variants** for the 16 Gb and 32 Gb HBM3 die
families.

## Before / after

\`\`\`
# before                          # after
HBM3_8Gb_8hi    (sid=2)           HBM3_8Gb_8hi    (sid=2)
HBM3_16Gb_8hi   (sid=2)           HBM3_16Gb_8hi   (sid=2)
                                  HBM3_16Gb_12hi  (sid=3)  # new
HBM3_32Gb_8hi   (sid=2)           HBM3_32Gb_8hi   (sid=2)
                                  HBM3_32Gb_12hi  (sid=3)  # new
HBM3_32Gb_16hi  (sid=4)           HBM3_32Gb_16hi  (sid=4)
\`\`\`

## Why

**12-Hi is the dominant HBM3E SK hynix / Samsung product
configuration in 2024-2025 production** — NVIDIA H200 and B200
ship with 12-Hi HBM3E packages (24 GB at 16 Gb dies, 48 GB at
32 Gb dies).

Without these presets, users modeling those platforms have to
either drop down to 8-Hi (under-stresses the channel) or jump
to 16-Hi (over-stresses).

Same shape as the existing 8 / 16-Hi entries — only \`sid\`
differs, every other org field stays at the family default.

## Verification

\`\`\`
\$ python3 -c \"
  import ramulator
  for p in ['HBM3_8Gb_8hi', 'HBM3_16Gb_8hi', 'HBM3_16Gb_12hi',
            'HBM3_32Gb_8hi', 'HBM3_32Gb_12hi', 'HBM3_32Gb_16hi']:
      d = ramulator.dram.HBM3(org_preset=p,
                              timing_preset='HBM3_6400Mbps')
      print(p, d.to_config()['org'])
\"
HBM3_8Gb_8hi   count=[1, 2, 2, 4, 4,  8192, 256]
HBM3_16Gb_8hi  count=[1, 2, 2, 4, 4, 16384, 256]
HBM3_16Gb_12hi count=[1, 2, 3, 4, 4, 16384, 256]
HBM3_32Gb_8hi  count=[1, 2, 2, 4, 4, 32768, 256]
HBM3_32Gb_12hi count=[1, 2, 3, 4, 4, 32768, 256]
HBM3_32Gb_16hi count=[1, 2, 4, 4, 4, 32768, 256]
\`\`\`

(\`count[2]\` is \`sid\`; the 12-Hi entries slot cleanly between
8-Hi and 16-Hi without disturbing any other field.)

## Test

- All 167 tests pass (\`tests/\` full run, 176 s)

## Related

Companion to my \`HBM4_32Gb_12Hi\` org-preset PR — after both
land the HBM3 / HBM4 product matrices both cover 4 / 8 / 12 /
16-Hi stacks. Together with my \`HBM3_8000/9200/9600Mbps\`
preset PR, the HBM3 family then covers the full HBM3E
production product space.