### PR TITLE
feat(hbm2): add 2800 / 3200 / 3600 Mbps HBM2E timing presets

### DIFF
--- a/python/ramulator/dram/hbm2.py
+++ b/python/ramulator/dram/hbm2.py
@@ -214,4 +214,26 @@ HBM2.timing_presets = {
         "nCCDS": 2, "nCCDL": 4, "nWTRS": 8, "nWTRL": 10,
         "tCK_ps": 833,
     },
+    # HBM2E speed grades. JEDEC HBM2 timings are fixed in ns and the
+    # CK-domain values scale linearly with rate (= 1.1667x / 1.333x / 1.5x
+    # of the 2400 Mbps reference). Min-bounded parameters (nCCDS=2) and
+    # the half-rate burst minimum (nBL=2) stay constant.
+    "HBM2_2800Mbps": {
+        "rate": 2800, "nBL": 2, "nCL": 20, "nRCDRD": 20, "nRCDWR": 16,
+        "nRP": 20, "nRAS": 47, "nRC": 67, "nWR": 22, "nRTPL": 7, "nCWL": 7,
+        "nCCDS": 2, "nCCDL": 5, "nWTRS": 9, "nWTRL": 12,
+        "tCK_ps": 714,
+    },
+    "HBM2_3200Mbps": {
+        "rate": 3200, "nBL": 2, "nCL": 23, "nRCDRD": 23, "nRCDWR": 19,
+        "nRP": 23, "nRAS": 53, "nRC": 76, "nWR": 25, "nRTPL": 8, "nCWL": 8,
+        "nCCDS": 2, "nCCDL": 5, "nWTRS": 11, "nWTRL": 13,
+        "tCK_ps": 625,
+    },
+    "HBM2_3600Mbps": {
+        "rate": 3600, "nBL": 2, "nCL": 26, "nRCDRD": 26, "nRCDWR": 21,
+        "nRP": 26, "nRAS": 60, "nRC": 86, "nWR": 29, "nRTPL": 9, "nCWL": 9,
+        "nCCDS": 2, "nCCDL": 6, "nWTRS": 12, "nWTRL": 15,
+        "tCK_ps": 555,
+    },
 }


### PR DESCRIPTION
## Summary

Adds three new HBM2 timing presets covering the **HBM2E
product line** (SK hynix Aquabolt-XL, Samsung Flashbolt,
Micron HBM2E, shipping since 2020):

| preset             | speed       | tCK_ps |
|--------------------|-------------|--------|
| \`HBM2_2800Mbps\`  | HBM2E early | 714    |
| \`HBM2_3200Mbps\`  | HBM2E common| 625    |
| \`HBM2_3600Mbps\`  | HBM2E top   | 555    |

## Before

HBM2 had three presets covering 1.6 / 2.0 / 2.4 Gbps — the
**base HBM2 spec only**. HBM2E products running at
2.8 - 3.6 Gbps had no in-tree preset, forcing every HBM2E
modeling task to either roll its own preset or mis-use the
2400 Mbps preset (under-stresses the controller).

## Derivation

Same approach as the existing v2.1 speed-grade scaling
(cf. the \`HBM4_8000Mbps\` / \`HBM4_16000Mbps\` presets, which
are exactly 2.0x apart on every CK-domain field). JEDEC HBM2
timings are fixed in nanoseconds, so the CK-domain values
scale linearly with rate:

\`\`\`python
for k in scaled_keys:
    new[k] = round(base[k] * (new_rate / base_rate))
\`\`\`

Min-bounded parameters (\`nCCDS=2\`) are floor-clamped in JEDEC
and stay constant. \`nBL=2\` is the half-rate burst minimum.

## Verification

\`\`\`
\$ python3 -c \"
  import ramulator
  for p in ['HBM2_2400Mbps', 'HBM2_2800Mbps',
            'HBM2_3200Mbps', 'HBM2_3600Mbps']:
      d = ramulator.dram.HBM2(org_preset='HBM2_8Gb',
                              timing_preset=p)
      cfg = d.to_config()
      print(f'{p}  per-pin Mbps={2_000_000/cfg[\\\"timing\\\"][-1]:.2f}')
\"
HBM2_2400Mbps   per-pin Mbps= 2400.96
HBM2_2800Mbps   per-pin Mbps= 2801.12
HBM2_3200Mbps   per-pin Mbps= 3200.00
HBM2_3600Mbps   per-pin Mbps= 3603.60
\`\`\`

(Within 0.1% of each target rate — same character of tCK
quantization drift as the existing 1.6 / 2.0 / 2.4 Gbps
entries.)

## Test

- All 167 tests pass (\`tests/\` full run, 176 s)

## Why this matters

HBM2E was the dominant HBM SKU from ~2020 to ~2023 (Google TPU
v3/v4, NVIDIA A100, AMD MI100, Intel Ponte Vecchio). Until this
PR, anyone modeling those platforms had to derive their own
HBM2E preset from JEDEC.

## Related

Same shape as my \`HBM3_8000/9200/9600Mbps\` and
\`HBM4_9600Mbps\` / \`HBM4_12800Mbps\` timing-preset PRs —
together those nine presets give a continuous HBM2 / HBM2E /
HBM3 / HBM3E / HBM4 speed-grade matrix.