### PR TITLE
feat(hbm2): add HBM2_16Gb org preset (16 Gb die density)

### DIFF
--- a/python/ramulator/dram/hbm2.py
+++ b/python/ramulator/dram/hbm2.py
@@ -190,6 +190,7 @@ HBM2.org_presets = {
     "HBM2_2Gb":  {"density": 2048, "dq": 64, "channel_width": 64, "pseudochannel": 2, "bankgroup": 4, "bank": 4, "row": 1<<14, "column": (1<<5) << 2},  # HBM CA already takes BL into account
     "HBM2_4Gb":  {"density": 4096, "dq": 64, "channel_width": 64, "pseudochannel": 2, "bankgroup": 4, "bank": 4, "row": 1<<15, "column": (1<<5) << 2},  # HBM CA already takes BL into account
     "HBM2_8Gb":  {"density": 8192, "dq": 64, "channel_width": 64, "pseudochannel": 2, "bankgroup": 4, "bank": 4, "row": 1<<16, "column": (1<<5) << 2},  # HBM CA already takes BL into account
+    "HBM2_16Gb": {"density": 16384, "dq": 64, "channel_width": 64, "pseudochannel": 2, "bankgroup": 4, "bank": 4, "row": 1<<17, "column": (1<<5) << 2},  # HBM2E 16 Gb die (Samsung Flashbolt, SK hynix Aquabolt-XL)
 }
 
 # Timing presets — primary timings only.


### PR DESCRIPTION
## Summary

Adds the **16 Gb per-die density** variant for HBM2 — the
top-end HBM2E die used in 2020-2023 production silicon.

## Before / after

\`\`\`
# before                          # after
HBM2_1Gb  (row = 1<<13)           HBM2_1Gb  (row = 1<<13)
HBM2_2Gb  (row = 1<<14)           HBM2_2Gb  (row = 1<<14)
HBM2_4Gb  (row = 1<<15)           HBM2_4Gb  (row = 1<<15)
HBM2_8Gb  (row = 1<<16)           HBM2_8Gb  (row = 1<<16)
                                  HBM2_16Gb (row = 1<<17)  # new
\`\`\`

## Why

HBM2E products shipped with 16 Gb dies (Samsung Flashbolt,
SK hynix Aquabolt-XL, Micron HBM2E), yielding **16 GB packages
at 8-Hi stack**. Real consuming platforms include:

- Google TPU v4
- NVIDIA A100 80GB
- AMD MI100 / MI200

Without this preset, users modeling those platforms had to
either drop to 8 Gb (under-stresses controller, wrong \`nRFC\`)
or roll their own \`org_preset\`.

Same shape as the existing 1 / 2 / 4 / 8 Gb entries — only
density and row count change. Both double for the next binary
step, matching the existing progression.

## Verification

\`\`\`
\$ python3 -c \"
  import ramulator
  for p in ['HBM2_1Gb', 'HBM2_2Gb', 'HBM2_4Gb', 'HBM2_8Gb', 'HBM2_16Gb']:
      d = ramulator.dram.HBM2(org_preset=p,
                              timing_preset='HBM2_2400Mbps')
      print(p, d.to_config()['org'])
\"
HBM2_1Gb  count=[1, 2, 4, 4,   8192, 128]
HBM2_2Gb  count=[1, 2, 4, 4,  16384, 128]
HBM2_4Gb  count=[1, 2, 4, 4,  32768, 128]
HBM2_8Gb  count=[1, 2, 4, 4,  65536, 128]
HBM2_16Gb count=[1, 2, 4, 4, 131072, 128]
\`\`\`

(Row count doubles cleanly; \`nRFC\` is auto-resolved from
density by \`HBM2.resolve_secondary_timings\` — the 16 Gb entry
picks up the larger refresh budget without any controller-side
change.)

## Test

- All 167 tests pass (\`tests/\` full run, 175 s)

## Related

Companion to my \`HBM2_2800/3200/3600Mbps\` HBM2E timing-preset
PR — together they let users combine the 16 Gb die density
with HBM2E speed grades to model the full HBM2E product
configuration space.