### PR TITLE
fix(addr_mapper): validate level sizes are powers of two

### DIFF
--- a/src/ramulator/controller/addr_mapper/addr_mapper_base.cpp
+++ b/src/ramulator/controller/addr_mapper/addr_mapper_base.cpp
@@ -1,6 +1,23 @@
 #include "ramulator/controller/addr_mapper/addr_mapper_base.h"
 
+#include <stdexcept>
+
+#include <fmt/format.h>
+
 namespace Ramulator {
+
+namespace {
+
+// Bit-slicing in the addr_mapper assumes every level dimension is a
+// power of two: it allocates calc_log2(size) bits and decodes via
+// `addr & ((1 << bits) - 1)`. When `size` is not a power of two the
+// allocated field can't represent every index — e.g. size = 3 gets
+// only 1 bit, silently aliasing index 2 onto index 0. Catch this at
+// init time with a clear message naming the offending level, instead
+// of letting the simulation produce wrong results.
+bool is_power_of_two(int n) { return n > 0 && (n & (n - 1)) == 0; }
+
+}  // namespace
 
 void AddrMapperBase::init() {
   const auto& dram_spec = *m_ctrl->m_device.m_spec;
@@ -8,7 +25,18 @@ void AddrMapperBase::init() {
   m_num_mapped_levels = dram_spec.level_count - 1;  // skip channel
   m_addr_bits.resize(m_num_mapped_levels);
   for (int i = 0; i < m_num_mapped_levels; i++) {
-    m_addr_bits[i] = calc_log2(level_sizes[i + 1]);
+    int size = level_sizes[i + 1];
+    if (!is_power_of_two(size)) {
+      const std::string& level_name = dram_spec.level_names[i + 1];
+      throw std::runtime_error(fmt::format(
+          "AddrMapperBase: level '{}' has size {} which is not a power of "
+          "two — bit-sliced address mapping cannot encode it without "
+          "aliasing. Either change the org preset to a power-of-two "
+          "dimension or extend the addr_mapper to support modulo "
+          "addressing.",
+          level_name, size));
+    }
+    m_addr_bits[i] = calc_log2(size);
   }
 
   // Column adjusted for prefetch


### PR DESCRIPTION
## What the bug looks like

\`AddrMapperBase::init()\` runs

\`\`\`cpp
m_addr_bits[i] = calc_log2(level_sizes[i + 1]);
\`\`\`

and both in-tree address mappers (\`RoBaRaCoCh\`,
\`ChRaBaRoCo\`) then decode addresses with

\`\`\`cpp
addr & ((1 << m_addr_bits[i]) - 1);
\`\`\`

This assumes every level dimension is a power of two:
\`calc_log2\` is floor-log2, and the mask only allocates
\`calc_log2(size)\` bits. If \`size = 3\`, the mask is 1 bit
wide and indices \`{0, 1, 2}\` collapse onto \`{0, 1, 0}\` —
**index 2 silently aliases onto index 0**. The simulation
runs to completion and emits wrong numbers, with no warning.

Every in-tree \`org_preset\` today happens to be all
power-of-two (sids of 1 / 2 / 4, banks of 4 / 8 / 16, etc.), so
this never fires — but the constraint is only implicit. Anyone
adding a realistic 12-Hi HBM stack (\`sid = 3\`, 36 GB SK hynix
HBM3E, 48 GB HBM4 product lines) trips the alias.

## The fix

Validate at \`init()\` time. If a level size is not a power of
two, throw a \`runtime_error\` naming the offending level, its
size, and both ways to resolve (change the org or extend the
mapper). The simulation **stops loudly at construction** instead
of producing silently-wrong results.

## Verification

\`\`\`
\$ python3 -c \"
  import ramulator
  ramulator.dram.HBM4.org_presets['HBM4_test'] = {
      'density': 32768, 'dq': 32, 'channel_width': 32,
      'pseudochannel': 2, 'sid': 3, 'bankgroup': 2, 'bank': 8,
      'row': 1<<14, 'column': (1<<5) << 3,
  }
  hbm4 = ramulator.dram.HBM4(
      org_preset='HBM4_test', timing_preset='HBM4_8000Mbps')
  # ... wire controller / mem / frontend, run sim()
\"
RuntimeError: AddrMapperBase: level 'Sid' has size 3 which is not
a power of two — bit-sliced address mapping cannot encode it
without aliasing. Either change the org preset to a power-of-two
dimension or extend the addr_mapper to support modulo addressing.
\`\`\`

## Test

- All 167 tests pass (\`tests/\` full run, 181 s) — no in-tree
  preset is affected; this only fires on user-supplied
  non-power-of-two level sizes.

## Related

Will need to land **before** my non-power-of-two HBM3 / HBM4
12-Hi org-preset PRs can ship usefully; those PRs add \`sid=3\`
and would otherwise hit the silent aliasing this PR turns into
an error.

EDIT — I'd recommend the maintainer rebase those two
preset PRs onto this one (or close them pending a follow-up
that extends the mapper to support non-power-of-two
dimensions). Either path is fine; flagging the dependency so
they aren't merged in the wrong order.