### PR TITLE
fix(simpleO3): validate LLC and core parameters at init

### DIFF
--- a/src/ramulator/frontend/impl/processor/simpleO3/simpleO3.cpp
+++ b/src/ramulator/frontend/impl/processor/simpleO3/simpleO3.cpp
@@ -60,6 +60,35 @@ class SimpleO3 final : public IFrontEnd, public Implementation {
     m_num_cores = m_traces.size();
     int llc_capacity_per_core = parse_capacity_str(m_llc_capacity_str);
 
+    // Validate parameters before constructing the LLC. Several of these
+    // feed integer divisions and bit shifts inside SimpleO3LLC's
+    // constructor; without these checks a misconfigured value silently
+    // becomes SIGFPE (linesize=0 -> division by zero in m_set_size
+    // computation) or a wrong-but-running simulation (e.g. capacity
+    // smaller than one cache line gives m_set_size=0, m_index_mask=-1,
+    // and the LLC indexes every set as set 0).
+    auto require_positive = [](int value, const char* name) {
+      if (value <= 0) {
+        throw std::runtime_error(
+            fmt::format("SimpleO3: {} must be > 0 (got {})", name, value));
+      }
+    };
+    require_positive(m_num_cores, "len(traces)");
+    require_positive(m_ipc, "ipc");
+    require_positive(m_depth, "inst_window_depth");
+    require_positive(m_llc_latency, "llc_latency");
+    require_positive(m_llc_linesize_bytes, "llc_linesize");
+    require_positive(m_llc_associativity, "llc_associativity");
+    require_positive(m_llc_num_mshr_per_core, "llc_num_mshr_per_core");
+    require_positive(llc_capacity_per_core, "llc_capacity_per_core");
+    int llc_set_bytes = m_llc_linesize_bytes * m_llc_associativity;
+    if (llc_capacity_per_core < llc_set_bytes) {
+      throw std::runtime_error(fmt::format(
+          "SimpleO3: llc_capacity_per_core ({} B) must hold at least one "
+          "associativity-way set ({} B = llc_linesize {} * llc_associativity {})",
+          llc_capacity_per_core, llc_set_bytes, m_llc_linesize_bytes, m_llc_associativity));
+    }
+
     RAMULATOR_CREATE_CHILD(m_translation, ITranslation);
 
     m_llc = std::make_unique<SimpleO3LLC>(m_clk, m_llc_latency, llc_capacity_per_core * m_num_cores,


### PR DESCRIPTION
## What the bug looks like

\`SimpleO3LLC\`'s constructor unconditionally computes

\`\`\`cpp
m_set_size     = m_size_bytes / (m_linesize_bytes * m_associativity);
m_index_mask   = m_set_size - 1;
m_index_offset = calc_log2(m_linesize_bytes);
\`\`\`

\`SimpleO3\` init parses these from user config but **never
checks they're positive**. Several misconfigurations silently
degrade or crash:

| input                       | result                                                                                |
|-----------------------------|---------------------------------------------------------------------------------------|
| \`llc_linesize=0\`          | **SIGFPE** — division by zero in \`m_set_size\` computation                          |
| \`llc_associativity=0\`     | **SIGFPE** — same path                                                                |
| \`llc_capacity < one set\`  | \`m_set_size=0\` → \`m_index_mask=-1\`, every address hashes to set 0 — silent FA cache |
| \`ipc=0\`                   | instruction window can never insert, simulation hangs                                 |
| \`inst_window_depth=0\`     | \`retire()\` called on empty window, simulation hangs                                 |
| \`llc_latency<=0\`          | hit/miss list scheduling at \`m_clk + latency\` stops being monotone                 |

## Reproducer (HEAD pre-fix)

\`\`\`
\$ python3 -c \"
  import ramulator
  fe = ramulator.frontend.SimpleO3(
      clock_ratio=8, llc_linesize=0,
      traces=['./examples/traces/example_inst.trace'],
      num_expected_insts=100,
      translation=ramulator.translation.NoTranslation(max_addr=2147483648),
  )
  ...wire HBM4 / mem / sim...
  sim.run()
\"
Floating point exception (core dumped)
\`\`\`

## The fix

Validate every LLC / core parameter that feeds an integer
division, bit-shift, or scheduling computation. A single
\`require_positive()\` helper covers \`ipc\` / \`inst_window_depth\` /
\`llc_latency\` / \`llc_linesize\` / \`llc_associativity\` /
\`llc_num_mshr_per_core\` / \`llc_capacity_per_core\` /
\`len(traces)\`, and a separate explicit check rejects capacity
smaller than one associativity-way set (the silent
fully-associative degradation).

## Verification

\`\`\`
\$ python3 ...   # exercise each bad value
OK  llc_linesize=0:           SimpleO3: llc_linesize must be > 0 (got 0)
OK  llc_associativity=0:      SimpleO3: llc_associativity must be > 0 (got 0)
OK  llc_latency=-1:           SimpleO3: llc_latency must be > 0 (got -1)
OK  ipc=0:                    SimpleO3: ipc must be > 0 (got 0)
OK  inst_window_depth=0:      SimpleO3: inst_window_depth must be > 0 (got 0)
OK  llc_capacity=tiny:        SimpleO3: llc_capacity_per_core (1024 B) must
                              hold at least one associativity-way set ...
\`\`\`

## Test

- All 167 tests pass (\`tests/\` full run, 180 s) — defaults are
  unaffected; this only fires on values the LLC can't handle.

## Related

Same defensive-init shape as the recently-merged base /
frontend validation PRs (\`parse_capacity_str\` strict parsing,
nop_counter / positive params, empty-trace UB protection).
Pairs naturally with #161 (addr_mapper power-of-two validation).