### PR TITLE
fix(translation): validate NoTranslation max_addr at init

### DIFF
--- a/src/ramulator/translation/impl/no_translation.cpp
+++ b/src/ramulator/translation/impl/no_translation.cpp
@@ -1,3 +1,7 @@
+#include <stdexcept>
+
+#include <fmt/format.h>
+
 #include "ramulator/base/base.h"
 #include "ramulator/base/param.h"
 #include "ramulator/frontend/i_frontend.h"
@@ -14,6 +18,15 @@ class NoTranslation : public ITranslation, public Implementation {
  public:
   void init() override {
     RAMULATOR_PARSE_PARAM(m_max_paddr, Addr_t, "max_addr").required();
+    // translate() does `req.addr % m_max_paddr` on every request.
+    // max_addr <= 0 turns that into integer modulo-by-zero or
+    // undefined-result modulo by a negative divisor, which manifests
+    // as a SIGFPE core dump partway through the simulation rather
+    // than a clear configuration error at construction.
+    if (m_max_paddr <= 0) {
+      throw std::runtime_error(fmt::format(
+          "NoTranslation: max_addr must be > 0 (got {})", m_max_paddr));
+    }
   };
 
   bool translate(Request& req) override {


### PR DESCRIPTION
## What the bug looks like

\`NoTranslation::translate()\` runs on every request:

\`\`\`cpp
req.addr = req.addr % m_max_paddr;
\`\`\`

\`NoTranslation::init()\` reads \`m_max_paddr\` as a required user
parameter but **never checks it**. Two bad values silently break:

| input          | result                                                                              |
|----------------|-------------------------------------------------------------------------------------|
| \`max_addr=0\` | **SIGFPE** (integer modulo by zero) on the first request reaching the controller   |
| \`max_addr<0\` | C++ integer modulo by negative divisor is impl-defined for negative \`req.addr\` — wrong wrap range either way |

The crash and the bad wrap both happen **well after
construction**, so the user sees \`Floating point exception\` with
no hint that the configuration was wrong.

## Reproducer (HEAD pre-fix)

\`\`\`
\$ python3 -c \"
  import ramulator
  tx = ramulator.translation.NoTranslation(max_addr=0)
  ... wire SimpleO3 + HBM4 ...
  sim.run()
\"
Floating point exception (core dumped)
\`\`\`

## The fix

Validate at \`init()\` time. If \`max_addr <= 0\`, throw with the
offending value. The simulation stops loudly at construction
instead of SIGFPE-ing later.

## Verification

\`\`\`
\$ python3 ...   # NoTranslation(max_addr=0)
RuntimeError: NoTranslation: max_addr must be > 0 (got 0)
\`\`\`

## Test

- All 167 tests pass (\`tests/\` full run, 181 s) — every existing
  preset uses \`max_addr > 0\`, so nothing else is affected.

## Related

Same defensive-init shape as #161 (addr_mapper power-of-two),
#162 (SimpleO3 LLC), #163 (controller_base buffer / watermark).
Together they turn four classes of silent failure (address
aliasing, SIGFPE in LLC, hang on buffer=0, SIGFPE in translate)
into clear errors at construction.