### PR TITLE
fix(refresh): use monotone clock check in AllBank and PerBank

### DIFF
--- a/src/ramulator/controller/refresh/impl/all_bank.cpp
+++ b/src/ramulator/controller/refresh/impl/all_bank.cpp
@@ -83,7 +83,12 @@ void AllBankRefresh::init() {
 }
 
 void AllBankRefresh::tick() {
-  if (m_ctrl->m_clk == m_next_refresh_cycle) {
+  // Use >= rather than == so a tick that skips past the scheduled
+  // refresh clock (e.g. tick frequency adjustment, paused-and-resumed
+  // simulation) still fires the refresh on the next tick instead of
+  // silently dropping it forever — matches HBM34PerBankRefresh's
+  // defensive shape.
+  if (m_ctrl->m_clk >= m_next_refresh_cycle) {
     m_next_refresh_cycle += m_nrefi;
     for (auto* ref_node : m_ref_nodes) {
       AddrVec_t addr_vec = build_addr_vec(ref_node);

--- a/src/ramulator/controller/refresh/impl/per_bank.cpp
+++ b/src/ramulator/controller/refresh/impl/per_bank.cpp
@@ -48,7 +48,11 @@ void PerBankRefresh::init() {
 }
 
 void PerBankRefresh::tick() {
-  if (m_ctrl->m_clk == m_next_refresh_cycle) {
+  // Use >= rather than == so a tick that skips past the scheduled
+  // refresh clock still fires the refresh on the next tick instead of
+  // silently dropping it forever — matches HBM34PerBankRefresh's
+  // defensive shape.
+  if (m_ctrl->m_clk >= m_next_refresh_cycle) {
     m_next_refresh_cycle += m_nrefipb;
 
     // Refresh one bank in round-robin order


### PR DESCRIPTION
## What the bug looks like

\`AllBankRefresh::tick()\` and \`PerBankRefresh::tick()\` schedule
refresh by tracking the next refresh clock and firing when the
controller's \`m_clk\` hits it **exactly**:

\`\`\`cpp
if (m_ctrl->m_clk == m_next_refresh_cycle) {
  m_next_refresh_cycle += m_nrefi;
  ...issue refresh...
}
\`\`\`

The \`==\` comparison assumes \`m_ctrl->m_clk\` monotonically
increases by 1 per refresh-manager tick and **never skips**. That
happens to hold for every in-tree controller today, but the
assumption is fragile and silent: if the controller is ever ticked
at a different rate (variable-rate stepping for fast-forward /
paused simulation), or if multiple controllers share a refresh
manager with mismatched clock domains, \`m_clk\` skips over
\`m_next_refresh_cycle\` and **the refresh never fires again** —
the device stops being refreshed, data integrity is lost, and the
simulation continues silently.

## The fix

Switch to \`>=\` — fire on or after the scheduled clock — matching
the defensive shape already used in \`HBM34PerBankRefresh\`
(\`per_bank_refresh.cpp:190\`):

\`\`\`cpp
if (m_ctrl->m_clk < m_next_refresh_clk) {
  return;
}
\`\`\`

With \`m_next_refresh_cycle\` still advanced by \`+= m_nrefi\`
after firing, this behaves **identically to \`==\`** when the
clock increments by 1 (every existing test) and **fires-on-
catch-up** when it doesn't.

No new failure paths: the existing throw on \`priority_send\`
failure remains; the difference is whether a missed schedule
silently disables refresh forever, or fires the moment the
controller next runs.

## Test

- All 167 tests pass (\`tests/\` full run, 180 s) — every
  existing controller ticks by 1, so the visible behavior is
  unchanged.

## Related

Same robustness shape as the recent param-validation PRs
(#161 addr_mapper power-of-two, #162 SimpleO3 LLC, #163
controller_base buffers, #164 NoTranslation max_addr): catches
a class of silent failures the tests don't currently exercise.