### PR TITLE
fix(latency_throughput_trace): validate streaming / range params at init

### DIFF
--- a/src/ramulator/frontend/impl/memory_trace/latency_throughput_trace.cpp
+++ b/src/ramulator/frontend/impl/memory_trace/latency_throughput_trace.cpp
@@ -93,6 +93,35 @@ class LatencyThroughputTrace : public IFrontEnd, public Implementation {
           "LatencyThroughputTrace: num_streaming_requests must be set when streaming_only=true");
     }
 
+    // The streaming-address index is computed as
+    //   col = (idx / m_total_bank_units) % m_stream_cls
+    //   row = (idx / m_total_bank_units / m_stream_cls) % m_num_rows
+    // and similar shapes for total_bank_units and num_cls — any of
+    // these being <= 0 silently degrades to SIGFPE the moment the
+    // streaming generator runs, well after construction.
+    // read_ratio is compared against a [0,99] uniform draw, so any
+    // value outside [0,100] silently locks the trace to all-read or
+    // all-write instead of the requested mix.
+    auto require_positive = [](int v, const char* name) {
+      if (v <= 0) {
+        throw std::runtime_error(fmt::format(
+            "LatencyThroughputTrace: {} must be > 0 (got {})", name, v));
+      }
+    };
+    require_positive(m_stream_cls, "stream_cls");
+    require_positive(m_total_bank_units, "total_bank_units");
+    require_positive(m_num_rows, "num_rows");
+    require_positive(m_num_cols, "num_cols");
+    require_positive(m_num_cls, "num_cls");
+    if (m_warmup_cycles < 0) {
+      throw std::runtime_error(fmt::format(
+          "LatencyThroughputTrace: warmup_cycles must be >= 0 (got {})", m_warmup_cycles));
+    }
+    if (m_read_ratio < 0 || m_read_ratio > 100) {
+      throw std::runtime_error(fmt::format(
+          "LatencyThroughputTrace: read_ratio must be in [0, 100] (got {})", m_read_ratio));
+    }
+
     m_stats.add("streaming_requests_sent", s_streaming_sent);
     m_stats.add("probe_requests_completed", s_probes_completed);
     m_stats.add("total_probe_latency", s_total_probe_latency);


### PR DESCRIPTION
## What the bug looks like

\`LatencyThroughputTrace\`'s address generator computes the
streaming index as:

\`\`\`cpp
int cls = static_cast<int>((idx / m_total_bank_units) % m_stream_cls);
int row = static_cast<int>((idx / m_total_bank_units / m_stream_cls) % m_num_rows);
\`\`\`

\`m_stream_cls\` / \`m_total_bank_units\` / \`m_num_rows\` /
\`m_num_cols\` / \`m_num_cls\` all feed integer divisions or
modulos in the streaming hot path, but \`init()\` **never
validates them**. Several misconfigurations silently break:

| input                           | result                                                     |
|---------------------------------|------------------------------------------------------------|
| \`stream_cls = 0\`              | **SIGFPE** — modulo by zero on the first streaming request |
| \`total_bank_units = 0\`        | **SIGFPE** — divisor in three different places             |
| \`num_rows = 0\`                | **SIGFPE** — same shape                                    |
| \`num_cols / num_cls = 0\`      | **SIGFPE** — flat-address composition                      |
| \`warmup_cycles < 0\`           | \`m_warmup_enabled\` stays false; user asked for warmup but silently runs without |
| \`read_ratio\` outside \`[0,100]\` | compared against \`uniform_int [0,99]\` draw — \`> 100\` locks all-read, \`< 0\` locks all-write |

## The fix

Validate at \`init()\` time. A single \`require_positive()\` helper
covers the five always-positive fields; explicit checks reject
\`warmup_cycles < 0\` and \`read_ratio\` out of \`[0, 100]\`. Each
error names the offending parameter and the value the user
supplied.

## Test

- All 167 tests pass (\`tests/\` full run, 180 s) — every existing
  test config passes; this only fires on misconfigured values.

## Related

Continuation of the defensive-init audit (#161 addr_mapper
power-of-two, #162 SimpleO3 LLC, #163 controller_base buffers,
#164 NoTranslation max_addr, #165 refresh monotone clock).
Together they convert silent divide-by-zero / address aliasing /
starvation into clear construction-time errors.