### PR TITLE
fix(cmd_trace_recorder): write int32-strided addr_vec to match header

### DIFF
--- a/src/ramulator/controller/plugin/impl/cmd_trace_recorder.cpp
+++ b/src/ramulator/controller/plugin/impl/cmd_trace_recorder.cpp
@@ -127,7 +127,19 @@ class CmdTraceRecorder : public IControllerPlugin, public Implementation {
     m_file.write(reinterpret_cast<const char*>(&cmd), sizeof(cmd));
     m_file.write(reinterpret_cast<const char*>(&type), sizeof(type));
     m_file.write(reinterpret_cast<const char*>(&src), sizeof(src));
-    m_file.write(reinterpret_cast<const char*>(req.addr_vec.data()), m_level_count * sizeof(int32_t));
+    // The header documents addr_vec elements as int32_t, but addr_vec
+    // itself is std::vector<int>. sizeof(int) is not guaranteed to equal
+    // sizeof(int32_t) — on ILP64 platforms where int is 8 bytes, the
+    // old `req.addr_vec.data()` reinterpret-cast with a 4-byte stride
+    // captured only the low 4 bytes of every other element and shifted
+    // the rest by 4 bytes per element, producing a binary file the
+    // documented decoder couldn't read.
+    //
+    // Copy through int32_t to match the header contract on every
+    // platform. This stage runs once per issued command — negligible
+    // versus the file write itself.
+    std::vector<int32_t> addr_vec32(req.addr_vec.begin(), req.addr_vec.end());
+    m_file.write(reinterpret_cast<const char*>(addr_vec32.data()), m_level_count * sizeof(int32_t));
   }
 };
 


### PR DESCRIPTION
## What the bug looks like

The binary mode header documents each record as

\`\`\`cpp
uint64_t clock
int32_t  command_id
int32_t  type_id
int32_t  source_id
int32_t  addr_vec[level_count]
\`\`\`

but \`write_binary_record()\` wrote \`addr_vec\` via

\`\`\`cpp
m_file.write(reinterpret_cast<const char*>(req.addr_vec.data()),
             m_level_count * sizeof(int32_t));
\`\`\`

\`req.addr_vec\` is \`std::vector<int>\`, and \`sizeof(int)\` is
not guaranteed to equal \`sizeof(int32_t)\`. On the **LP64**
platforms that ship the binary today they happen to match, so
the bug never fires in CI; on **ILP64** platforms (some 64-bit
Unix systems) where \`sizeof(int)\` is 8, the cast writes a
4-byte stride into 8-byte elements: **half the bytes get
dropped** and \`addr_vec[k]\` is read from the middle of
\`int{k/2 + 1}\` on decode. The documented decoder produces
nonsense without any error.

## The fix

Copy \`addr_vec\` through \`int32_t\` before writing — the
resulting buffer is exactly the size and stride the header
advertises on every platform. Cost is one alloc + one element
copy per issued command, dwarfed by the file write itself.

## Test

- All 167 tests pass (\`tests/\` full run, 180 s).
- Visible behavior on **LP64 (where the bug never fired) is
  unchanged**; the file format on ILP64 now matches the header.

## Related

Independent fix; not part of the param-validation audit chain
but found during the same v2.1 sweep.