### PR TITLE
fix(generic_dram_system): bounds-check channel_id from channel mapper

### DIFF
--- a/src/ramulator/memory_system/impl/generic_dram_system.cpp
+++ b/src/ramulator/memory_system/impl/generic_dram_system.cpp
@@ -62,6 +62,17 @@ class GenericDRAMSystem final : public IMemorySystem, public Implementation {
     // Controller::send() handles address mapping internally.
     m_channel_mapper->apply(req);
     int channel_id = req.addr_vec[0];
+    // Defend against a channel mapper that emits a channel id outside the
+    // controller range (e.g. PassThroughChannelMapper called with a request
+    // whose frontend never populated addr_vec[0] — the slot stays at its
+    // default -1 and `m_controllers[-1]->send(req)` is out-of-bounds UB).
+    if (channel_id < 0 || channel_id >= static_cast<int>(m_controllers.size())) {
+      throw std::runtime_error(fmt::format(
+          "GenericDRAM: channel mapper produced channel_id {} outside [0, {}) — "
+          "check that the channel mapper sets req.addr_vec[0] correctly (or that "
+          "the frontend pre-populated it when using PassThroughChannelMapper).",
+          channel_id, m_controllers.size()));
+    }
     bool is_success = m_controllers[channel_id]->send(req);
 
     if (is_success) {


### PR DESCRIPTION
## What the bug looks like

\`GenericDRAMSystem::send()\` reads the channel id directly from
the request's \`addr_vec[0]\` after the channel mapper runs and
forwards into \`m_controllers[channel_id]\` **without a bounds
check**:

\`\`\`cpp
m_channel_mapper->apply(req);
int channel_id = req.addr_vec[0];
bool is_success = m_controllers[channel_id]->send(req);
\`\`\`

For the two well-behaved in-tree channel mappers
(\`CacheLineInterleave\`, which masks the channel bits, and a
correctly-used \`PassThroughChannelMapper\`, where the frontend
pre-sets \`addr_vec[0]\`), \`channel_id\` is always a valid index.

But \`PassThroughChannelMapper\` documents that it **assumes**
\`addr_vec[0]\` is set by the frontend, never enforces it, and
copies \`req.addr\` through unchanged. A frontend that doesn't
set \`addr_vec[0]\` (or any future channel mapper that returns
\`-1\` to signal \"no route\") drops straight into

\`\`\`cpp
m_controllers[-1]->send(req);
\`\`\`

which is **out-of-bounds vector access** — undefined behavior
(it usually segfaults, but on a hot path under release builds it
might silently corrupt and continue). No error message points
at the channel mapper as the root cause.

## The fix

Validate \`channel_id\` against \`m_controllers.size()\` before
indexing. On a bad value, throw a \`runtime_error\` naming the
channel id, the controller count, and which component to look
at (channel mapper / frontend with PassThroughChannelMapper).

## Test

- All 167 tests pass (\`tests/\` full run, 179 s). No in-tree
  test triggers a bad \`channel_id\`, so visible behavior is
  unchanged.

## Related

Continuation of the defensive-init / defensive-runtime audit
chain (#161 / #162 / #163 / #164 / #165 / #166 / #167 / #168).