### PR TITLE
fix(cmd_trace_recorder): detect open failure instead of silently dropping

### DIFF
--- a/src/ramulator/controller/plugin/impl/cmd_trace_recorder.cpp
+++ b/src/ramulator/controller/plugin/impl/cmd_trace_recorder.cpp
@@ -42,9 +42,23 @@ class CmdTraceRecorder : public IControllerPlugin, public Implementation {
 
     if (m_binary) {
       m_file.open(filepath, std::ios::binary);
-      write_binary_header(spec);
     } else {
       m_file.open(filepath);
+    }
+    // ofstream::open silently sets failbit on failure (missing directory,
+    // permission denied, disk full, etc.). Subsequent writes then no-op
+    // and the user gets neither a trace file nor an error message — the
+    // simulation prints stats and exits with success while the recording
+    // was never made. Fail loudly here instead.
+    if (!m_file.is_open()) {
+      throw std::runtime_error(fmt::format(
+          "CmdTraceRecorder: failed to open trace file '{}' (path missing, "
+          "permission denied, or disk full)",
+          filepath));
+    }
+    if (m_binary) {
+      write_binary_header(spec);
+    } else {
       write_text_header(spec);
     }
   }


### PR DESCRIPTION
## What the bug looks like

\`CmdTraceRecorder::setup()\` opens the per-channel trace file
but **never checks whether the open succeeded**:

\`\`\`cpp
m_file.open(filepath, std::ios::binary);
write_binary_header(spec);
\`\`\`

When the open fails (missing parent directory, permission
denied, disk full, read-only mount, ...) \`std::ofstream\`
silently sets \`failbit\`. The header write becomes a no-op,
every later \`write_binary_record\` / \`write_text_record\` call
is also a no-op, and \`finalize()\` closes a stream that never
had a file.

The simulation prints stats and **exits with success while the
trace file the user asked for was never created**. No log line,
no error.

## Reproducer

\`\`\`
\$ python3 -c \"
  import ramulator
  ...wire HBM4 + CmdTraceRecorder(path='/nonexistent_dir/trace.csv')...
  sim.run()
\"
Controller cycles:     ...
Avg read latency:      ...
# ...no /nonexistent_dir/trace.csv.ch0 created, no warning
\`\`\`

## The fix

Check \`m_file.is_open()\` right after the open call. If it
failed, throw a \`runtime_error\` naming the failed path and the
most likely causes (path missing, permission denied, disk full)
— the simulation stops loudly at controller setup instead of
running a recording that goes nowhere.

## Test

- All 167 tests pass (\`tests/\` full run, 179 s). No in-tree
  test references \`CmdTraceRecorder\` with a path it can't
  write to, so visible behavior is unchanged.

## Related

Continuation of the defensive-init / defensive-runtime audit
chain (#161 / #162 / #163 / #164 / #165 / #166 / #167 / #168 /
#169).