### PR TITLE
fix(simpleO3): reject empty trace at construction

### DIFF
--- a/src/ramulator/frontend/impl/processor/simpleO3/core.cpp
+++ b/src/ramulator/frontend/impl/processor/simpleO3/core.cpp
@@ -46,6 +46,16 @@ SimpleO3Core::Trace::Trace(std::string file_path_str) {
 
   trace_file.close();
   m_trace_length = m_trace.size();
+  // get_next_inst() dereferences m_trace[idx] and advances
+  // `(idx + 1) % m_trace_length`. With an empty trace file (the read
+  // loop above completes without iterating), m_trace_length=0 turns the
+  // very first access into out-of-bounds vector access plus a modulo
+  // by zero — SIGFPE / UB at SimpleO3Core construction.
+  if (m_trace_length == 0) {
+    throw std::runtime_error(fmt::format(
+        "Trace {} is empty — at least one instruction is required",
+        file_path_str));
+  }
 }
 
 const SimpleO3Core::Trace::Inst& SimpleO3Core::Trace::get_next_inst() {


### PR DESCRIPTION
## What the bug looks like

\`SimpleO3Core::Trace\`'s constructor reads each non-empty line
into \`m_trace\`, then sets \`m_trace_length = m_trace.size()\`.
With an **empty trace file** (zero lines), the while-loop
completes without iterating and \`m_trace_length\` stays at 0.

\`SimpleO3Core::Trace::get_next_inst()\` then runs:

\`\`\`cpp
const Inst& inst = m_trace[m_curr_trace_idx];
m_curr_trace_idx = (m_curr_trace_idx + 1) % m_trace_length;
\`\`\`

For an empty trace this means

\`\`\`cpp
const Inst& inst = m_trace[0];               // out-of-bounds (UB)
m_curr_trace_idx = 1 % 0;                    // SIGFPE
\`\`\`

both reached during \`SimpleO3Core\` construction (the
constructor prefetches the first instruction). The user sees
only \`Floating point exception (core dumped)\` — no hint that
the trace was empty.

## Reproducer (HEAD pre-fix)

\`\`\`
\$ touch /tmp/empty.trace
\$ python3 -c \"
  import ramulator
  ...wire SimpleO3(traces=['/tmp/empty.trace'], ...) + HBM4 + sim...
  sim = ramulator.Simulation(fe, mem)
\"
Floating point exception (core dumped)
\`\`\`

## The fix

Validate \`m_trace_length > 0\` right after the read loop. If
the trace produced no instructions, throw a \`runtime_error\`
naming the file. The user gets a clear error pointing at the
cause instead of a SIGFPE during construction.

## Verification

\`\`\`
\$ python3 ...      # empty trace
RuntimeError: Trace /tmp/empty.trace is empty —
              at least one instruction is required
\`\`\`

## Test

- All 167 tests pass (\`tests/\` full run, 179 s). Every existing
  test trace has at least one instruction.

## Related

Continuation of the defensive-init audit chain (#161 / #162 /
#163 / #164 / #165 / #166 / #167 / #168 / #169 / #170 / #171).