### PR TITLE
fix(io): validate LoadStoreTrace empty input and LLC checkpoint paths

### DIFF
--- a/src/ramulator/frontend/impl/memory_trace/loadstore_trace.cpp
+++ b/src/ramulator/frontend/impl/memory_trace/loadstore_trace.cpp
@@ -104,6 +104,17 @@ class LoadStoreTrace : public IFrontEnd, public Implementation {
     trace_file.close();
 
     m_trace_length = m_trace.size();
+    // tick() reads m_trace[m_curr_trace_idx] and advances
+    // `(idx + 1) % m_trace_length`. An empty trace file leaves
+    // m_trace_length=0, so the first tick is out-of-bounds vector
+    // access + modulo by zero. is_finished() returns true immediately
+    // for empty input, so users may not crash but get a completed
+    // simulation that did literally nothing — silent no-op trace.
+    if (m_trace_length == 0) {
+      throw std::runtime_error(fmt::format(
+          "Trace {} is empty — at least one LD/ST line is required",
+          file_path_str));
+    }
   };
 
   bool is_finished() override {

--- a/src/ramulator/frontend/impl/processor/simpleO3/llc.cpp
+++ b/src/ramulator/frontend/impl/processor/simpleO3/llc.cpp
@@ -3,6 +3,9 @@
 #include <cassert>
 #include <algorithm>
 #include <fstream>
+#include <stdexcept>
+
+#include <fmt/format.h>
 
 namespace Ramulator {
 
@@ -235,6 +238,15 @@ SimpleO3LLC::MSHR_t::iterator SimpleO3LLC::check_mshr_hit(Addr_t addr) {
 void SimpleO3LLC::serialize(std::string serialization_filename) {
   std::ofstream serialization_file;
   serialization_file.open(serialization_filename, std::ios::out);
+  // ofstream::open silently sets failbit when the path is unwritable.
+  // The subsequent CSV writes then no-op and the user gets neither a
+  // snapshot file nor an error — the LLC checkpoint is silently lost.
+  if (!serialization_file.is_open()) {
+    throw std::runtime_error(fmt::format(
+        "SimpleO3LLC::serialize: failed to open '{}' for writing "
+        "(path missing, permission denied, or disk full)",
+        serialization_filename));
+  }
 
   serialization_file << "index,addr,tag,dirty" << std::endl;
   for (auto it1 = m_cache_sets.begin(); it1 != m_cache_sets.end(); it1++) {
@@ -248,6 +260,15 @@ void SimpleO3LLC::serialize(std::string serialization_filename) {
 void SimpleO3LLC::deserialize(std::string serialization_filename) {
   std::ifstream serialization_file;
   serialization_file.open(serialization_filename, std::ios::in);
+  // Same failure mode as serialize(): a silent open failure here means
+  // every getline returns empty and the LLC starts cold despite the
+  // user explicitly asking to restore state.
+  if (!serialization_file.is_open()) {
+    throw std::runtime_error(fmt::format(
+        "SimpleO3LLC::deserialize: failed to open '{}' for reading "
+        "(path missing or permission denied)",
+        serialization_filename));
+  }
 
   std::string file_line;
   std::getline(serialization_file, file_line);  // Skip the first line, which is the header


### PR DESCRIPTION
Three loud-error conversions for silent failures found during
the v2.1 audit sweep:

## 1. LoadStoreTrace empty trace

\`init_trace()\` parses each line into \`m_trace\`, then sets
\`m_trace_length = m_trace.size()\`. With an **empty trace
file** the read loop completes without iterating and
\`m_trace_length\` stays 0. \`tick()\` then runs

\`\`\`cpp
const Trace& t = m_trace[m_curr_trace_idx];
m_curr_trace_idx = (m_curr_trace_idx + 1) % m_trace_length;
\`\`\`

on the first cycle — out-of-bounds vector access plus modulo
by zero. \`is_finished()\` happens to also return true
immediately (\`0 >= 0\`), so depending on the harness's
\`tick\` / \`is_finished\` ordering the user sees either SIGFPE
or **a completed simulation that did literally nothing** —
silent no-op trace.

**Fix:** throw on \`m_trace_length == 0\` right after the read
loop, naming the file path.

## 2. \`SimpleO3LLC::serialize\` open failure

\`ofstream::open\` silently sets failbit when the path is
unwritable (missing parent directory, permission denied, disk
full, ...). The subsequent CSV writes then no-op and the user
gets neither a snapshot file nor an error — **the LLC
checkpoint is silently lost**.

**Fix:** check \`is_open()\` right after \`open()\` and throw
with the path and common causes.

## 3. \`SimpleO3LLC::deserialize\` open failure

Same shape on the read path: silent open failure means every
\`getline\` returns empty and the LLC starts cold despite the
user explicitly asking to restore state from a checkpoint.

**Fix:** same \`is_open()\` check on the read side.

## Test

- All 167 tests pass (\`tests/\` full run, 179 s). None of the
  existing tests trigger any of these conditions.

## Related

Continuation of the defensive-init / defensive-runtime audit
chain (#161 / #162 / #163 / #164 / #165 / #166 / #167 / #168 /
#169 / #170 / #171 / #172).