### PR TITLE
fix(closed_cap): reject cap <= 0 instead of degenerate PRE-injection loop

### DIFF
--- a/src/ramulator/controller/rowpolicy/impl/closed_cap.cpp
+++ b/src/ramulator/controller/rowpolicy/impl/closed_cap.cpp
@@ -1,4 +1,7 @@
+#include <stdexcept>
 #include <vector>
+
+#include <fmt/format.h>
 
 #include "ramulator/base/param.h"
 #include "ramulator/controller/controller_base.h"
@@ -34,6 +37,22 @@ class ClosedCAPRowPolicy : public IRowPolicy, public Implementation {
     m_device = &m_ctrl->m_device;
     m_spec = m_device->m_spec;
     RAMULATOR_PARSE_PARAM(m_cap, int, "cap").default_val(4);
+    // cap <= 0 makes the pre_schedule predicate
+    //   m_col_accesses[i] < m_cap   // false for every bank (counts start at 0)
+    // perpetually false, so the policy injects a PREpb against every
+    // bank on every cycle (only blocked by the on-issue reset of the
+    // injected flag). The simulation runs but pre_schedule wastes work
+    // and the policy stops behaving like a column-access cap. Reject
+    // the value loudly so the user knows their config is meaningless
+    // for ClosedCAP.
+    if (m_cap <= 0) {
+      throw std::runtime_error(fmt::format(
+          "ClosedCAP: cap must be > 0 (got {}) — a cap of 0 or less makes "
+          "the column-access count never reach the cap and degenerates "
+          "into a per-cycle PREpb-injection loop. Use a CloseRow policy "
+          "for cap-1 semantics, or supply a positive cap.",
+          m_cap));
+    }
 
     m_cmd_prepb = m_spec->get_command_id("PREpb");
     m_cmd_rd = m_spec->get_command_id("RD");


### PR DESCRIPTION
## What the bug looks like

\`ClosedCAPRowPolicy\` parses its \`cap\` parameter without
bounds and uses it in two predicates that drive the entire
policy:

\`\`\`cpp
// try_upgrade_command: skip if not yet at cap
if (m_col_accesses[flat_bank_id] < m_cap) {
  return;
}

// pre_schedule: skip injecting PRE if not yet at cap
if (m_col_accesses[i] < m_cap || m_prepb_injected[i]) {
  continue;
}
\`\`\`

Both predicates assume \`m_cap >= 1\`.

With **\`cap = 0\`** (or negative): \`m_col_accesses[i]\` is
initialized to 0, so \`m_col_accesses[i] < m_cap\` is
permanently \`0 < 0 = false\` for every bank that hasn't issued
a closing command yet. The predicate never excludes anyone —
the policy decides every bank is ready to close on every cycle.

Concretely:

- \`try_upgrade_command\` upgrades \`RD -> RDA\` / \`WR -> WRA\`
  on every column access **without honoring the cap at all**
- \`pre_schedule\` injects an explicit \`PREpb\` against every
  bank on every cycle until \`on_issue\` resets
  \`m_prepb_injected\`, then injects again next cycle

The simulation runs but \`ClosedCAP\` no longer implements
\"close-after-N\" semantics — it degenerates into \"close every
access\" with a per-cycle PRE-injection loop on every bank.

## The fix

Validate \`cap >= 1\` at \`init()\` time and throw with a clear
explanation that includes the right alternative (\`CloseRow\`
for cap-1 semantics) and the offending value. All in-tree
configurations use \`cap > 0\`, so existing behavior is
unchanged.

## Test

- All 167 tests pass (\`tests/\` full run, 181 s). Default
  \`cap=4\` and every test config uses \`cap >= 1\`, so the new
  check fires only on misconfigured input.

## Related

Continuation of the defensive-init audit chain (#161 / #162 /
#163 / #164 / #165 / #166 / #167 / #168 / #169 / #170 / #171 /
#172 / #173).