### PR TITLE
fix(dram_spec): validate timing_constraints shape before indexing

### DIFF
--- a/src/ramulator/dram/dram_spec.cpp
+++ b/src/ramulator/dram/dram_spec.cpp
@@ -1,5 +1,9 @@
 #include "ramulator/dram/dram_spec.h"
 
+#include <stdexcept>
+
+#include <fmt/format.h>
+
 namespace Ramulator {
 
 void DRAMSpec::load_config(const ConfigNode& config) {
@@ -44,9 +48,41 @@ void DRAMSpec::load_config(const ConfigNode& config) {
     int latency = f[3].as<int>();
     int window = f.size() > 4 ? f[4].as<int>() : 1;
     bool sibling = f.size() > 5 ? f[5].as<bool>() : false;
+
+    // Validate the constraint shape before indexing timing_cons. A
+    // mistyped or out-of-range level or command id would otherwise
+    // silently corrupt adjacent vectors via timing_cons[level][cmd_id]
+    // (no bounds check). A window of 0 is even worse: the per-node
+    // m_cmd_history is sized to `max(window) = 0` and then
+    // update_timing reads m_cmd_history[command][window - 1] = [-1] —
+    // out-of-bounds on an empty deque, undefined behavior in the
+    // simulation hot path.
+    if (level < 0 || level >= level_count) {
+      throw std::runtime_error(fmt::format(
+          "DRAMSpec: timing_constraints level {} is outside [0, {})",
+          level, level_count));
+    }
+    if (window <= 0) {
+      throw std::runtime_error(fmt::format(
+          "DRAMSpec: timing_constraints window must be >= 1 (got {}); a "
+          "window of 0 would size the history to 0 and turn the "
+          "node-level update into out-of-bounds deque access",
+          window));
+    }
+    auto require_cmd_id = [&](int cmd_id, const char* role) {
+      if (cmd_id < 0 || cmd_id >= command_count) {
+        throw std::runtime_error(fmt::format(
+            "DRAMSpec: timing_constraints {} command id {} is outside [0, {})",
+            role, cmd_id, command_count));
+      }
+    };
     for (const auto& p : f[1].seq()) {
+      int preceding_cmd = p.as<int>();
+      require_cmd_id(preceding_cmd, "preceding");
       for (const auto& fc : f[2].seq()) {
-        timing_cons[level][p.as<int>()].push_back({fc.as<int>(), latency, window, sibling});
+        int following_cmd = fc.as<int>();
+        require_cmd_id(following_cmd, "following");
+        timing_cons[level][preceding_cmd].push_back({following_cmd, latency, window, sibling});
       }
     }
   }


### PR DESCRIPTION
## What the bug looks like

\`DRAMSpec::load_config()\` parses each timing-constraint entry
and indexes \`timing_cons[level][cmd_id]\` **without
bounds-checking either dimension**:

\`\`\`cpp
int level = f[0].as<int>();
...
for (const auto& p : f[1].seq()) {
  for (const auto& fc : f[2].seq()) {
    timing_cons[level][p.as<int>()].push_back({fc.as<int>(), ...});
  }
}
\`\`\`

Three malformed inputs slip through:

| input                                       | result                                                                              |
|---------------------------------------------|-------------------------------------------------------------------------------------|
| \`level >= level_count\` or \`level < 0\`   | out-of-bounds vector write into adjacent memory or segfault                         |
| preceding/following cmd id out of range     | same shape, indexed into the inner vector                                           |
| \`window <= 0\`                             | \`DRAMNode\` sizes \`m_cmd_history[cmd]\` to \`max(window) = 0\`; \`update_timing\` then reads \`m_cmd_history[command][-1]\` — **UB on size-0 deque** in the simulation hot path |

All three are silent in v2.1 today because the in-tree Python
specs only emit well-formed entries, but the C++
\`load_config()\` is a **public boundary** (config files, custom
specs, downstream forks) and should reject malformed inputs at
the boundary rather than UB later.

## The fix

Validate at parse time. For each \`timing_constraints\` entry:

- check \`level\` in \`[0, level_count)\`
- check \`window >= 1\`
- check preceding and following cmd ids in \`[0, command_count)\`

Each error names the offending field and the value supplied so
the user can find the bad entry in the source config.

## Test

- All 167 tests pass (\`tests/\` full run, 182 s). Every in-tree
  spec passes the new checks unchanged.

## Related

Continuation of the defensive-init audit chain (#161 / #162 /
#163 / #164 / #165 / #166 / #167 / #168 / #169 / #170 / #171 /
#172 / #173 / #174). **First defensive PR against the spec
loader** rather than a runtime path.