### PR TITLE
fix(mop4clxor): reject column field too narrow for the 4-CL XOR offset

### DIFF
--- a/src/ramulator/controller/addr_mapper/impl/mop4clxor.cpp
+++ b/src/ramulator/controller/addr_mapper/impl/mop4clxor.cpp
@@ -1,3 +1,7 @@
+#include <stdexcept>
+
+#include <fmt/format.h>
+
 #include "ramulator/controller/addr_mapper/i_addr_mapper.h"
 #include "ramulator/controller/addr_mapper/addr_mapper_base.h"
 
@@ -12,6 +16,22 @@ class MOP4CLXOR : public IAddrMapper, public AddrMapperBase {
 
 void MOP4CLXOR::init() {
   AddrMapperBase::init();
+  // apply() hard-codes the low two column bits and then reads the
+  // *remaining* column bits via slice_lower_bits(addr, m_addr_bits[col] - 2).
+  // The "4" in the mapper's name is exactly this two-bit chunk:
+  // four consecutive cache lines share a bank/row before stepping to
+  // the next bank. When the column field is fewer than 2 bits, that
+  // subtraction goes negative and slice_lower_bits ends up shifting
+  // and masking with a negative width — undefined behavior, silently
+  // corrupting every request the mapper sees.
+  if (m_addr_bits[m_col_idx] < 2) {
+    throw std::runtime_error(fmt::format(
+        "MOP4CLXOR: column field has only {} addressable bit(s) after "
+        "internal_prefetch_size, but the 4-CL XOR scheme reserves the low "
+        "2 column bits for the offset chunk. Increase the column dimension "
+        "or pick a non-XOR address mapper.",
+        m_addr_bits[m_col_idx]));
+  }
 }
 
 void MOP4CLXOR::apply(Request& req) {


### PR DESCRIPTION
## What the bug looks like

\`MOP4CLXOR\` hard-codes the low two column bits as the
4-cache-line offset chunk, then reads the *remaining* column
bits with:

\`\`\`cpp
req.addr_vec[m_col_idx + 1] +=
    slice_lower_bits(addr, m_addr_bits[m_col_idx] - 2) << 2;
\`\`\`

When \`m_addr_bits[m_col_idx] < 2\` (the column dimension, after
the \`internal_prefetch_size\` subtraction in \`AddrMapperBase\`,
is fewer than 2 addressable bits), the subtraction goes
negative. \`slice_lower_bits<int>()\` then runs:

\`\`\`cpp
Integral_t lbits = addr & ((1 << num_bits) - 1);  // shift by negative
addr >>= num_bits;                                 // shift by negative
\`\`\`

both **undefined behavior** in C++. The mapper silently
corrupts every request without ever surfacing an error.

This isn't hit by any in-tree spec — every standard's column
dimension after prefetch is comfortably wider than 2 bits — but
the mapper has no precondition documented anywhere, so a custom
small-column spec or a future preset with a tighter column
walks straight into UB.

## The fix

Validate at \`init()\` time. If the column field is narrower
than the 2-bit offset chunk the scheme requires, throw a clear
\`runtime_error\` naming the actual width and suggesting either
a larger column or a non-XOR mapper.

## Test

- All 167 tests pass (\`tests/\` full run, 181 s). Every in-tree
  spec passes the new check unchanged.

## Related

Continuation of the defensive-init audit chain (#161 / #162 /
#163 / #164 / #165 / #166 / #167 / #168 / #169 / #170 / #171 /
#172 / #173 / #174 / #175 / #176). Pairs naturally with
#161 (which catches non-power-of-two level dimensions in the
same \`AddrMapperBase\` init path).