### PR TITLE
fix(readwrite_trace): reject empty input and addr_vec int-truncation

### DIFF
--- a/src/ramulator/frontend/impl/memory_trace/readwrite_trace.cpp
+++ b/src/ramulator/frontend/impl/memory_trace/readwrite_trace.cpp
@@ -1,7 +1,9 @@
+#include <climits>
 #include <filesystem>
 #include <fmt/format.h>
 #include <fstream>
 #include <iostream>
+#include <stdexcept>
 
 #include "ramulator/base/param.h"
 #include "ramulator/frontend/i_frontend.h"
@@ -96,8 +98,18 @@ class ReadWriteTrace : public IFrontEnd, public Implementation {
       tokenize(addr_vec_tokens, tokens[1], ",");
 
       AddrVec_t addr_vec;
-      for (const auto& token : addr_vec_tokens) {
-        addr_vec.push_back(static_cast<int>(std::stoll(token)));
+      for (size_t k = 0; k < addr_vec_tokens.size(); k++) {
+        // AddrVec_t is std::vector<int>. Silently narrowing the parsed
+        // 64-bit value would let a too-large row index alias onto a
+        // wrong (or negative) bank/row index and the simulation would
+        // run with the wrong workload — fail loudly instead.
+        long long v = std::stoll(addr_vec_tokens[k]);
+        if (v < 0 || v > INT_MAX) {
+          throw std::runtime_error(fmt::format(
+              "Trace {} line {}: addr_vec[{}] = {} is outside [0, INT_MAX]",
+              file_path_str, line_num, k, v));
+        }
+        addr_vec.push_back(static_cast<int>(v));
       }
 
       m_trace.push_back({is_write, addr_vec});
@@ -106,6 +118,19 @@ class ReadWriteTrace : public IFrontEnd, public Implementation {
     trace_file.close();
 
     m_trace_length = m_trace.size();
+    // tick() reads m_trace[m_curr_trace_idx] and advances
+    // `(idx + 1) % m_trace_length`. An empty trace file leaves
+    // m_trace_length = 0; the very first tick would be
+    // out-of-bounds vector access plus modulo by zero (SIGFPE).
+    // is_finished() returns true immediately for empty input, so
+    // depending on the harness's tick / is_finished ordering the
+    // user either crashes or runs a simulation that did literally
+    // nothing — silent no-op trace.
+    if (m_trace_length == 0) {
+      throw std::runtime_error(fmt::format(
+          "Trace {} is empty — at least one R/W line is required",
+          file_path_str));
+    }
   };
 
   bool is_finished() override {


### PR DESCRIPTION
Two loud-error conversions for silent failures in the same
\`ReadWriteTrace\` frontend.

## 1. Empty trace file

\`init_trace()\` runs the line-parsing loop without iterating
when the file is empty, leaving \`m_trace_length = 0\`. \`tick()\`
then runs

\`\`\`cpp
const Trace& t = m_trace[m_curr_trace_idx];
m_curr_trace_idx = (m_curr_trace_idx + 1) % m_trace_length;
\`\`\`

on the first cycle — out-of-bounds vector access plus modulo by
zero. \`is_finished()\` happens to also return true immediately
(\`0 >= 0\`), so depending on the harness's \`tick\` /
\`is_finished\` ordering the user sees either SIGFPE or **a
completed simulation that did literally nothing** — silent
no-op trace.

Same shape as the \`LoadStoreTrace\` and \`SimpleO3\` trace
empty-file fixes (#172, #173). Throws on \`m_trace_length == 0\`
right after the read loop, naming the file path.

## 2. \`addr_vec\` \`int\` overflow / negative

The previous code dropped each parsed \`long long\` into an
\`int\` via a silent narrowing cast:

\`\`\`cpp
addr_vec.push_back(static_cast<int>(std::stoll(token)));
\`\`\`

A row index of \`2^31\` or higher (or any negative value)
**silently truncates to a different (or negative) index** —
the simulation runs with the wrong workload and produces wrong
stats without any warning.

Parse into \`long long\`, range-check against \`[0, INT_MAX]\`,
and throw with the file, line, position, and offending value
before the cast.

## Test

- All 167 tests pass (\`tests/\` full run, 179 s). Every
  in-tree trace passes both checks unchanged.

## Related

Continuation of the defensive-input audit chain (#161 / #162 /
#163 / #164 / #165 / #166 / #167 / #168 / #169 / #170 / #171 /
#172 / #173 / #174 / #175 / #176 / #177). The empty-file leg
finishes the symmetric coverage with \`SimpleO3\` (#172) and
\`LoadStoreTrace\` (#173).