### PR TITLE
fix(codegen): re-raise ImportError on broken DRAM spec modules

### DIFF
--- a/python/ramulator/codegen.py
+++ b/python/ramulator/codegen.py
@@ -22,18 +22,31 @@ _CUSTOM_COMPONENTS = set()
 
 
 def _discover_standards():
-    """Import all known standard modules to trigger registration."""
+    """Import all known standard modules to trigger registration.
+
+    Re-raises ImportError on broken spec modules with a clear message —
+    the prior `except ImportError: pass` silently dropped the affected
+    standard from the registry, so `codegen` printed "Generated …" for
+    everything else and exited 0, leaving the broken standard absent
+    from the build output with no warning.
+    """
     import importlib
     import pkgutil
 
     import ramulator.dram as dram_pkg
 
     for _, name, _ in pkgutil.iter_modules(dram_pkg.__path__):
-        if name not in ("spec", "base", "__init__"):
-            try:
-                importlib.import_module(f"ramulator.dram.{name}")
-            except ImportError:
-                pass
+        if name in ("spec", "base", "__init__"):
+            continue
+        try:
+            importlib.import_module(f"ramulator.dram.{name}")
+        except ImportError as e:
+            raise ImportError(
+                f"codegen: failed to import ramulator.dram.{name} "
+                f"during standard discovery — fix the import error in "
+                f"that spec file or rename it out of the dram/ package. "
+                f"Original error: {e}"
+            ) from e
 
     return dict(DRAMStandard._registry)
 


### PR DESCRIPTION
## What the bug looks like

\`_discover_standards()\` walks every module under
\`python/ramulator/dram/\` and tries to import each one to trigger
\`DRAMStandard\` registration:

\`\`\`python
for _, name, _ in pkgutil.iter_modules(dram_pkg.__path__):
    if name not in (\"spec\", \"base\", \"__init__\"):
        try:
            importlib.import_module(f\"ramulator.dram.{name}\")
        except ImportError:
            pass
\`\`\`

The bare \`except ImportError: pass\` **silently drops** any spec
whose import chain fails — broken module-level import, missing
dependency, typo in a \`from X import Y\`, accidentally-incorrect
spec class registration. The affected standard never makes it
into \`DRAMStandard._registry\`, so codegen prints

\`\`\`
Generated 8 DRAM standard(s): DDR3, DDR4, DDR5, GDDR6, HBM1, HBM2, HBM3, LPDDR5
\`\`\`

(silently 9 → 8) and exits 0. The build then has **no C++ header
for the missing standard**, and downstream
\`import ramulator.dram.HBM4\` fails with a confusing \"module
not found\" at runtime, very far from the actual cause.

## The fix

Re-raise as a new \`ImportError\` that names the spec file and
chains the original error. The user gets the file path and the
actual import message at the first run of \`codegen\`, instead of
a missing-output mystery later.

## Verification

\`\`\`
\$ python3 -m ramulator codegen --dry-run | tail -2
Generated 9 DRAM standard(s): DDR3, DDR4, DDR5, GDDR6, HBM1, HBM2, HBM3, HBM4, LPDDR5
Generated 27 Python component wrapper(s)
\`\`\`

Same number of standards as before; the change only affects the
failure path.

## Test

- All 167 tests pass (\`tests/\` full run, 181 s) — no in-tree
  spec has a broken import, so visible behavior is unchanged.

## Related

Continuation of the defensive-init / defensive-input audit
chain (#161 / #162 / #163 / #164 / #165 / #166 / #167 / #168 /
#169 / #170 / #171 / #172 / #173 / #174 / #175 / #176 / #177 /
#178). **First defensive PR against the Python codegen** rather
than C++ runtime.