### PR TITLE
fix(lpddr5_controller): validate split-activate and WCK timing params

### DIFF
--- a/src/ramulator/controller/impl/lpddr5_controller.cpp
+++ b/src/ramulator/controller/impl/lpddr5_controller.cpp
@@ -100,6 +100,25 @@ void LPDDR5Controller::init() {
   m_nCWL = spec.get_timing_value("nCWL");
   m_nBL = spec.get_timing_value("nBL");
   m_nWCKPST = spec.get_timing_value("nWCKPST");
+  // Validate the LPDDR5-specific timing values the controller reads
+  // directly. move_to_activating() computes the per-bank ACT2 deadline
+  // as `m_clk + m_nAAD`, so a non-positive nAAD makes the deadline
+  // collapse to "now" and starves every owned ACT2 candidate.
+  // extend_wck_expiry() uses nCL / nCWL / nBL / nWCKPST to push out
+  // m_wck_expiry; non-positive values silently never extend, freezing
+  // CAS-sync into the false branch and quietly disabling the
+  // optimization without an error.
+  if (m_nAAD <= 0) {
+    throw std::runtime_error(fmt::format(
+        "LPDDR5Controller: nAAD must be > 0 (got {}) — feeds the ACT2 deadline",
+        m_nAAD));
+  }
+  if (m_nCL <= 0 || m_nCWL <= 0 || m_nBL <= 0 || m_nWCKPST < 0) {
+    throw std::runtime_error(fmt::format(
+        "LPDDR5Controller: nCL ({}), nCWL ({}), nBL ({}) must be > 0 and "
+        "nWCKPST ({}) must be >= 0 — feed extend_wck_expiry()",
+        m_nCL, m_nCWL, m_nBL, m_nWCKPST));
+  }
 
   m_activating_buffer.max_size = m_device.m_bank_nodes.size();
   m_act2_owner_valid.assign(m_device.m_bank_nodes.size(), false);


### PR DESCRIPTION
\`LPDDR5Controller::init()\` reads five spec timing values it
uses directly:

\`\`\`cpp
m_nAAD     = spec.get_timing_value(\"nAAD\");
m_nCL      = spec.get_timing_value(\"nCL\");
m_nCWL     = spec.get_timing_value(\"nCWL\");
m_nBL      = spec.get_timing_value(\"nBL\");
m_nWCKPST  = spec.get_timing_value(\"nWCKPST\");
\`\`\`

then feeds them into:

\`\`\`cpp
move_to_activating()    m_act2_deadline[id] = m_clk + m_nAAD
extend_wck_expiry(cmd)  exp = m_clk + (read ? m_nCL : m_nCWL)
                                     + m_nBL + m_nWCKPST
\`\`\`

| input | result |
|---|---|
| \`nAAD <= 0\` | every ACT2 deadline collapses to \"now\" → \`pick_urgent_act2()\` force-issues immediately, split-activate window silently disabled |
| \`nCL\`/\`nCWL\`/\`nBL\` non-positive | \`extend_wck_expiry()\` never extends \`m_wck_expiry\` → \`try_issue_cas_sync()\` always falls through → **WCK2CK CAS optimization silently disabled** |
| \`nWCKPST < 0\` | same WCK shape (0 is a valid spec value, so this is the only non-zero floor) |

## The fix

Validate the five params at \`init()\` time. \`nAAD\` / \`nCL\` /
\`nCWL\` / \`nBL\` must be \`> 0\`; \`nWCKPST\` must be \`>= 0\`.
Each error names the offending field and its value.

## Test

- All 167 tests pass (\`tests/\` full run, 180 s). Every in-tree
  LPDDR5 preset passes the new checks.

## Related

Continuation of the defensive-init audit chain (#161 .. #180).