### PR TITLE
fix(simpleO3_llc): replace assert(false) with throw in need_eviction

### DIFF
--- a/src/ramulator/frontend/impl/processor/simpleO3/llc.cpp
+++ b/src/ramulator/frontend/impl/processor/simpleO3/llc.cpp
@@ -189,9 +189,16 @@ SimpleO3LLC::CacheSet_t::iterator SimpleO3LLC::allocate_line(CacheSet_t& set, Ad
 
 bool SimpleO3LLC::need_eviction(const CacheSet_t& set, Addr_t addr) {
   if (std::find_if(set.begin(), set.end(), [addr, this](Line l) { return (get_tag(addr) == l.tag); }) != set.end()) {
-    // Due to MSHR, the program can't reach here. Just for checking
-    assert(false);
-    return false;
+    // The MSHR coalescing path in send() should make this unreachable.
+    // assert(false) crashes debug builds but is stripped from release
+    // builds — release would then return false silently, telling the
+    // caller "no eviction needed" for an already-present-in-cache
+    // address, which causes the second push_back to allocate a
+    // duplicate line for the same tag and corrupts LRU bookkeeping.
+    // Throw so the invariant is enforced in every build.
+    throw std::logic_error(
+        "SimpleO3LLC::need_eviction: address already present in the set — "
+        "MSHR coalescing should have absorbed this request in send()");
   } else {
     if (set.size() < m_associativity) {
       return false;


### PR DESCRIPTION
## What the bug looks like

\`SimpleO3LLC::need_eviction()\` asserts that the address isn't
already in the set:

\`\`\`cpp
if (std::find_if(set.begin(), set.end(), [addr, this](Line l) {
      return (get_tag(addr) == l.tag); }) != set.end()) {
  // Due to MSHR, the program can't reach here. Just for checking
  assert(false);
  return false;
}
\`\`\`

The comment is right that the MSHR coalescing path in \`send()\`
should make this branch unreachable. But **\`assert(false)\` is
compiled away in release builds**, leaving the function to
silently \`return false\` — telling the caller \"no eviction
needed\" for an address that already has a line. \`allocate_line()\`
then walks past \`need_eviction\` and does

\`\`\`cpp
set.push_back({addr, get_tag(addr)});
\`\`\`

allocating a **second** cache line for the same tag. From then
on the set has two lines with the same tag — \`check_set_hit\`
picks the first match (the older one), the new dirty bit gets
dropped on the second push_back's default-initialized line, and
LRU bookkeeping is corrupted for that set.

## The fix

Replace the assert with a \`std::logic_error\` throw that fires
in every build. The release simulation now stops loudly on the
invariant violation instead of silently corrupting the cache.

## Test

- All 167 tests pass (\`tests/\` full run, 180 s). No in-tree
  test hits this branch (the MSHR path holds), so visible
  behavior is unchanged.

## Related

Continuation of the defensive audit chain (#161 .. #182).
Belongs to the same class of fixes as #165 (refresh-manager
clock-equality fragility) — both replace an \"obvious
invariant\" with a check that survives release builds.