### PR TITLE
docs(examples): add HBM2 example configuration script

### DIFF
--- a/examples/hbm2_config.py
+++ b/examples/hbm2_config.py
@@ -1,0 +1,67 @@
+"""HBM2 example configuration script.
+
+Third in the HBM example series (after ``hbm4_config.py`` and
+``hbm3_loadstore_config.py``). Demonstrates HBM2 / HBM2E wiring:
+
+  - ``HBM12`` controller (used for both HBM1 and HBM2, hence the name)
+  - per-bank refresh manager scoped to the HBM PseudoChannel level
+  - 32-byte transactions (HBM2 BL4 over 64-bit DQ per pseudochannel)
+
+Run from the repo root:
+
+    python examples/hbm2_config.py
+"""
+
+import ramulator
+
+# SimpleO3 frontend with the standard example trace. HBM2 transactions
+# are 32 bytes (BL4 * 64-bit DQ per pseudochannel / 16), so the LLC
+# line size must match — leaving the default 64 B trips
+# GenericDRAM::send's size validation.
+frontend = ramulator.frontend.SimpleO3(
+    clock_ratio=8,
+    llc_linesize=32,
+    traces=["./examples/traces/example_inst.trace"],
+    num_expected_insts=500000,
+    translation=ramulator.translation.NoTranslation(max_addr=2147483648),
+)
+
+# HBM2 reference device: 8 Gb per die, 8-Hi stack -> 8 GB package.
+# HBM2 (unlike HBM3/4) has no Sid level; stack height is implicit.
+hbm2 = ramulator.dram.HBM2(
+    org_preset="HBM2_8Gb",
+    timing_preset="HBM2_2400Mbps",
+)
+
+# HBM1/2 share the same controller implementation ("HBM12") — the
+# pre-HBM3 dual-bus protocol family. Per-bank refresh keeps each bank
+# refresh-stall to the per-bank tRFCpb budget rather than freezing
+# the whole pseudochannel.
+ctrl = ramulator.controller.HBM12(
+    dram=hbm2,
+    scheduler=ramulator.scheduler.FRFCFS(),
+    refresh_manager=ramulator.refresh_manager.PerBank(),
+    row_policy=ramulator.row_policy.Open(),
+    addr_mapper=ramulator.addr_mapper.RoBaRaCoCh(),
+)
+
+mem = ramulator.memory_system.GenericDRAM(
+    clock_ratio=3,
+    controllers=[ctrl],
+    channel_mapper=ramulator.channel_mapper.CacheLineInterleave(),
+)
+
+sim = ramulator.Simulation(frontend, mem)
+sim.run()
+
+stats = sim.stats
+if stats:
+    ctrl_stats = stats["memory_system"]["controller"]
+
+    print(f"Controller cycles:     {ctrl_stats['cycles']}")
+    print(f"Avg read latency:      {ctrl_stats['avg_read_latency']:.1f} cycles")
+    print(f"Read requests:         {ctrl_stats['num_read_reqs']}")
+    print(f"Write requests:        {ctrl_stats['num_write_reqs']}")
+    print(f"Row hits:              {ctrl_stats['row_hits']}")
+    print(f"Row misses:            {ctrl_stats['row_misses']}")
+    print(f"Row conflicts:         {ctrl_stats['row_conflicts']}")


### PR DESCRIPTION
Third entry in the HBM example series after
\`examples/hbm4_config.py\` (SimpleO3 + HBM4) and
\`examples/hbm3_loadstore_config.py\` (LoadStoreTrace + HBM3).
Covers the HBM2 / HBM2E common case:

- SimpleO3 frontend (cache-modeling instruction trace)
- HBM12 controller (used for both HBM1 and HBM2)
- PerBank refresh manager — keeps refresh-stall per-bank
  instead of freezing the full pseudochannel
- \`llc_linesize=32\` to match HBM2's 32-byte transaction size

## Why

The repo currently has no end-to-end HBM2 example in the new
v2.1 Python API. Users porting HBM2 / HBM2E (Aquabolt-XL /
Flashbolt / A100 80GB / TPU v4) configurations have to derive
the wiring from scratch — including the HBM2-specific choices
that aren't obvious from the DDR4 template:

| concern              | DDR4 template       | HBM2 (correct)                |
|----------------------|---------------------|-------------------------------|
| controller           | \`GenericDDR\`      | \`HBM12\` (shared with HBM1)  |
| refresh manager      | \`AllBank(scope=Rank)\` | \`PerBank()\` — HBM2 has no Rank level |
| LLC line size        | 64 B (default)      | **32 B** (HBM2 tx size)       |

The script sets all of these correctly and runs end-to-end out
of the box.

## Verification

\`\`\`
\$ python examples/hbm2_config.py
Controller cycles:     81294
Avg read latency:      42.2 cycles
Read requests:         6
Write requests:        0
Row hits:              2
Row misses:            4
Row conflicts:         0
\`\`\`

Lower avg latency than the HBM4 example (133.8 cycles) reflects
HBM2's smaller per-pin rate and shorter tCL / nRCD timings
against the same cache-line trace.

## Related

Completes the HBM2 / HBM3 / HBM4 example triplet. Same
boilerplate stripped down to highlight only the HBM2-specific
differences from the DDR4 baseline.