### PR TITLE
fix(loadstore_trace): reject negative parsed address

### DIFF
--- a/src/ramulator/frontend/impl/memory_trace/loadstore_trace.cpp
+++ b/src/ramulator/frontend/impl/memory_trace/loadstore_trace.cpp
@@ -98,6 +98,16 @@ class LoadStoreTrace : public IFrontEnd, public Implementation {
       } else {
         addr = std::stoll(tokens[1]);
       }
+      // Address is forwarded straight to the memory system as the
+      // request's target physical address. A negative value here
+      // bypasses NoTranslation's positive-modulo wrap and reaches
+      // the channel mapper / addr mapper as a large unsigned offset,
+      // producing arbitrary addresses without any warning.
+      if (addr < 0) {
+        throw std::runtime_error(fmt::format(
+            "Trace {} line {}: addr must be >= 0 (got {})",
+            file_path_str, line_num, addr));
+      }
       m_trace.push_back({is_write, addr});
     }
 


### PR DESCRIPTION
## What the bug looks like

\`init_trace()\` accepts either decimal or hex (0x-prefixed) for
each line's address. After \`std::stoll()\` the value lands in
\`Addr_t\` (\`int64_t\`) and is fed straight to the memory system
on each tick:

\`\`\`cpp
Request req(t.addr, t.is_write ? ...);
req.size_bytes = m_memory_system->get_tx_bytes();
m_memory_system->send(req);
\`\`\`

There's **no positive check**. A trace line like

\`\`\`
LD -16
ST 0xFFFFFFFFFFFFFFFF    # parses as a negative int64
\`\`\`

bypasses \`NoTranslation\`'s \`req.addr % m_max_paddr\` wrap
(negative modulo by a positive divisor is impl-defined and
typically returns a negative result), feeds a negative addr
into the channel mapper, and the mapper interprets it as a huge
unsigned offset on the shift / & operations. The simulation
runs to completion with arbitrary off-spec request addresses
and no warning.

## The fix

Reject \`addr < 0\` with a clear \`runtime_error\` that names the
file, line, and parsed value. Same shape as the read_write_trace
fix in #178 and the SimpleO3 trace fix in #180.

## Test

- All 167 tests pass (\`tests/\` full run, 176 s). Every in-tree
  LoadStoreTrace line has a non-negative address.

## Related

Continuation of the defensive-input audit chain (#161 .. #184).