### PR TITLE
docs(examples): add DDR3 and GDDR6 example configuration scripts

### DIFF
--- a/examples/ddr3_config.py
+++ b/examples/ddr3_config.py
@@ -1,0 +1,57 @@
+"""DDR3 example configuration script.
+
+Legacy DDR3 reference — DDR3 + GenericDDR is the simplest config
+in v2.1 (no rank scope arg, no RFM, no split-activate). Useful as
+a smoke-test starting point or for studies that compare a modern
+spec (DDR5 / LPDDR5 / HBM) against the DDR3 baseline.
+
+Run from the repo root:
+
+    python examples/ddr3_config.py
+"""
+
+import ramulator
+
+frontend = ramulator.frontend.SimpleO3(
+    clock_ratio=8,
+    # DDR3 BL8 over x8 DQ = 64 B / rank — matches default LLC line size.
+    traces=["./examples/traces/example_inst.trace"],
+    num_expected_insts=500000,
+    translation=ramulator.translation.NoTranslation(max_addr=2147483648),
+)
+
+# DDR3 reference device — DDR3-1600H, 2 Gb x8, 1 rank.
+ddr3 = ramulator.dram.DDR3(
+    org_preset="DDR3_2Gb_x8",
+    timing_preset="DDR3_1600H",
+    rank=1,
+)
+
+ctrl = ramulator.controller.GenericDDR(
+    dram=ddr3,
+    scheduler=ramulator.scheduler.FRFCFS(),
+    refresh_manager=ramulator.refresh_manager.AllBank(),
+    row_policy=ramulator.row_policy.Open(),
+    addr_mapper=ramulator.addr_mapper.RoBaRaCoCh(),
+)
+
+mem = ramulator.memory_system.GenericDRAM(
+    clock_ratio=3,
+    controllers=[ctrl],
+    channel_mapper=ramulator.channel_mapper.CacheLineInterleave(),
+)
+
+sim = ramulator.Simulation(frontend, mem)
+sim.run()
+
+stats = sim.stats
+if stats:
+    ctrl_stats = stats["memory_system"]["controller"]
+
+    print(f"Controller cycles:     {ctrl_stats['cycles']}")
+    print(f"Avg read latency:      {ctrl_stats['avg_read_latency']:.1f} cycles")
+    print(f"Read requests:         {ctrl_stats['num_read_reqs']}")
+    print(f"Write requests:        {ctrl_stats['num_write_reqs']}")
+    print(f"Row hits:              {ctrl_stats['row_hits']}")
+    print(f"Row misses:            {ctrl_stats['row_misses']}")
+    print(f"Row conflicts:         {ctrl_stats['row_conflicts']}")

--- a/examples/gddr6_config.py
+++ b/examples/gddr6_config.py
@@ -1,0 +1,63 @@
+"""GDDR6 example configuration script.
+
+Graphics-DDR6 reference — the GPU-side DRAM standard used by
+GeForce / Radeon discrete GPUs. Same controller flow as DDR4 /
+DDR5 (GenericDDR), but the spec layer brings GDDR6's wider DQ
+(x16) and higher per-pin rates.
+
+Channel scope: GDDR6 has no Rank, so AllBank refreshes scope to
+the Channel level (handled automatically by AllBank — same
+behavior as for HBM).
+
+Run from the repo root:
+
+    python examples/gddr6_config.py
+"""
+
+import ramulator
+
+frontend = ramulator.frontend.SimpleO3(
+    clock_ratio=8,
+    # GDDR6 double-channel mode: each tx is 32 B.
+    llc_linesize=32,
+    traces=["./examples/traces/example_inst.trace"],
+    num_expected_insts=500000,
+    translation=ramulator.translation.NoTranslation(max_addr=2147483648),
+)
+
+# GDDR6 reference device — 8 Gb x16 die at 16 Gbps per pin
+# ("GDDR6_2000_1250mV_double" — the double-channel-mode preset that
+# matches modern GeForce / Radeon traffic).
+gddr6 = ramulator.dram.GDDR6(
+    org_preset="GDDR6_8Gb_x16",
+    timing_preset="GDDR6_2000_1250mV_double",
+)
+
+ctrl = ramulator.controller.GenericDDR(
+    dram=gddr6,
+    scheduler=ramulator.scheduler.FRFCFS(),
+    refresh_manager=ramulator.refresh_manager.AllBank(),
+    row_policy=ramulator.row_policy.Open(),
+    addr_mapper=ramulator.addr_mapper.RoBaRaCoCh(),
+)
+
+mem = ramulator.memory_system.GenericDRAM(
+    clock_ratio=3,
+    controllers=[ctrl],
+    channel_mapper=ramulator.channel_mapper.CacheLineInterleave(),
+)
+
+sim = ramulator.Simulation(frontend, mem)
+sim.run()
+
+stats = sim.stats
+if stats:
+    ctrl_stats = stats["memory_system"]["controller"]
+
+    print(f"Controller cycles:     {ctrl_stats['cycles']}")
+    print(f"Avg read latency:      {ctrl_stats['avg_read_latency']:.1f} cycles")
+    print(f"Read requests:         {ctrl_stats['num_read_reqs']}")
+    print(f"Write requests:        {ctrl_stats['num_write_reqs']}")
+    print(f"Row hits:              {ctrl_stats['row_hits']}")
+    print(f"Row misses:            {ctrl_stats['row_misses']}")
+    print(f"Row conflicts:         {ctrl_stats['row_conflicts']}")


### PR DESCRIPTION
Final pair completes per-standard example coverage. After this
PR the \`examples/\` directory has one runnable end-to-end
script for every DRAM standard v2.1 ships:

| file | spec | controller |
|---|---|---|
| \`example_config.py\` (existing) | DDR4 | GenericDDR |
| \`ddr3_config.py\` (new) | DDR3 | GenericDDR |
| \`ddr5_config.py\` | DDR5 | GenericDDR |
| \`gddr6_config.py\` (new) | GDDR6 | GenericDDR |
| \`hbm2_config.py\` | HBM2 | HBM12 |
| \`hbm3_loadstore_config.py\` | HBM3 | HBM34 + LoadStoreTrace |
| \`hbm4_config.py\` | HBM4 | HBM34 |
| \`lpddr5_config.py\` | LPDDR5 | LPDDR5 (split-activate) |

## What each new example shows

- **DDR3**: simplest spec — no rank-scope arg, no RFM, no
  split-activate. Useful as a smoke-test baseline and for
  comparison studies against modern specs.

- **GDDR6**: GPU-side DRAM. Same controller flow as DDR
  (GenericDDR) but with wider DQ (x16) and higher per-pin
  rates. No Rank level, so AllBank auto-scopes to Channel
  (same behavior as for HBM).

## Verification

\`\`\`
\$ python examples/ddr3_config.py
...Avg read latency: 31.2 cycles...

\$ python examples/gddr6_config.py
...Avg read latency: 71.7 cycles...
\`\`\`