### PR TITLE
feat(hbm4): add HBM4_11200Mbps timing preset

### DIFF
--- a/python/ramulator/dram/hbm4.py
+++ b/python/ramulator/dram/hbm4.py
@@ -187,6 +187,21 @@ HBM4.timing_presets = {
         "nRFCpb": 560, "nRREFD": 8,
         "tCK_ps": 500,
     },
+    "HBM4_11200Mbps": {
+        # 1.4x of HBM4_8000Mbps. Intermediate first-wave HBM4 product
+        # target (between the HBM4_9600Mbps first-wave preset and the
+        # HBM4_12800Mbps second wave) — matches early HBM4 silicon
+        # samples that didn't quite hit the 12.8 Gbps validation target.
+        # tCK_ps = round(500 / 1.4) = 357.
+        "rate": 11200, "nBL": 2, "nCL": 28, "nCWL": 14,
+        "nRC": 126, "nRAS": 80, "nRP": 46, "nRCDRD": 55, "nRCDWR": 27,
+        "nRRDL": 10, "nRRDS": 7, "nFAW": 42, "nRTP": 17, "nWR": 59,
+        "nCCDL": 4, "nCCDS": 2, "nCCDR": 2,
+        "nWTRL": 18, "nWTRS": 12, "nRTW": 35,
+        "nPPD": 2,
+        "nRFCpb": 784, "nRREFD": 8,
+        "tCK_ps": 357,
+    },
     "HBM4_16000Mbps": {
         "rate": 16000, "nBL": 2, "nCL": 40, "nCWL": 20,
         "nRC": 180, "nRAS": 114, "nRP": 66, "nRCDRD": 78, "nRCDWR": 38,


### PR DESCRIPTION
1.4x of HBM4_8000Mbps. Intermediate first-wave HBM4 product target (between HBM4_9600Mbps and HBM4_12800Mbps) — matches early HBM4 silicon samples that didn't quite hit the 12.8 Gbps validation target. tCK_ps = round(500/1.4) = 357.

## Verification

```
$ python3 -c "
  import ramulator
  d = ramulator.dram.HBM4(org_preset='HBM4_32Gb_8Hi',
                          timing_preset='HBM4_11200Mbps')
  print('Mbps:', round(2_000_000/d.to_config()['timing'][-1], 2))
"
Mbps: 11235.96
```

(Same character of tCK quantization drift as the existing 8000/9600/12800/16000 Mbps presets.)

## Related

Sits alongside HBM4 9600 / 11200 / 12800 / 14400 Mbps roadmap presets — together they cover the full HBM4 first / intermediate / second / third-wave product line.