### PR TITLE
feat(hbm4): add HBM4_64Gb_8Hi org preset (HBM4E density)

### DIFF
--- a/python/ramulator/dram/hbm4.py
+++ b/python/ramulator/dram/hbm4.py
@@ -174,6 +174,13 @@ HBM4.org_presets = {
     "HBM4_32Gb_4Hi":  {"density": 32768, "dq": 32, "channel_width": 32, "pseudochannel": 2, "sid": 1, "bankgroup": 2, "bank": 8, "row": 1<<14, "column": (1<<5) << 3},  # HBM CA already takes BL into account
     "HBM4_32Gb_8Hi":  {"density": 32768, "dq": 32, "channel_width": 32, "pseudochannel": 2, "sid": 2, "bankgroup": 2, "bank": 8, "row": 1<<14, "column": (1<<5) << 3},  # HBM CA already takes BL into account
     "HBM4_32Gb_16Hi": {"density": 32768, "dq": 32, "channel_width": 32, "pseudochannel": 2, "sid": 4, "bankgroup": 2, "bank": 8, "row": 1<<14, "column": (1<<5) << 3},  # HBM CA already takes BL into account
+    # 64 Gb HBM4 die — HBM4E forward-looking density. Doubles row count
+    # (1<<15) versus the 32 Gb base; at 8-Hi stack the per-channel
+    # density (16 GB) sits exactly at the high end of the in-tree
+    # nRFC table, matching the SK hynix HBM4E roadmap entry-level
+    # die. 16-Hi at this density exceeds the current nRFC table (32 GB
+    # per channel); add it once HBM4E nRFC is published.
+    "HBM4_64Gb_8Hi": {"density": 65536, "dq": 32, "channel_width": 32, "pseudochannel": 2, "sid": 2, "bankgroup": 2, "bank": 8, "row": 1<<15, "column": (1<<5) << 3},
 }
 
 HBM4.timing_presets = {


### PR DESCRIPTION
Forward-looking HBM4E die density. Doubles row count (`1<<15`) versus the existing 32 Gb base; at 8-Hi stack the per-channel density (16 GB) sits exactly at the high end of the in-tree nRFC table, matching the SK hynix HBM4E roadmap entry-level die.

## Note on 16-Hi

Adding `HBM4_64Gb_16Hi` at this density would yield 32 GB per channel — that exceeds the current `_resolve_nRFC()` table's upper bound (16 GB), so the org_preset raises `ValueError`. Holding off on the 16-Hi variant until JEDEC publishes HBM4E nRFC values that the table can match.

## Verification

```
$ python3 -c "
  import ramulator
  for p in ['HBM4_32Gb_8Hi','HBM4_64Gb_8Hi']:
      d = ramulator.dram.HBM4(org_preset=p,
                              timing_preset='HBM4_8000Mbps')
      print(p, d.to_config()['org'])
"
HBM4_32Gb_8Hi org: {'dq': 32, 'count': [1, 2, 2, 2, 8, 16384, 256]}
HBM4_64Gb_8Hi org: {'dq': 32, 'count': [1, 2, 2, 2, 8, 32768, 256]}
```