### PR TITLE
feat(hbm3): add HBM3 4-Hi org presets (8 Gb and 16 Gb)

### DIFF
--- a/python/ramulator/dram/hbm3.py
+++ b/python/ramulator/dram/hbm3.py
@@ -212,6 +212,10 @@ HBM3.org_presets = {
     # die density = 4 Gb, channel density = 4 Gb
     "HBM3_4Gb":  {"density": 4096, "dq": 32, "channel_width": 32, "pseudochannel": 2, "sid": 1, "bankgroup": 4, "bank": 4, "row": 1<<14, "column": (1<<5) << 3},  # HBM CA already takes BL into account
     # die density = 8 Gb, channel density = 4 Gb
+    # HBM3 4-Hi entries (sid=1): low-end stacks for low-power /
+    # embedded HBM3 workloads (NVIDIA Jetson Thor-class, automotive).
+    "HBM3_8Gb_4hi":  {"density": 8192, "dq": 32, "channel_width": 32, "pseudochannel": 2, "sid": 1, "bankgroup": 4, "bank": 4, "row": 1<<13, "column": (1<<5) << 3},
+    "HBM3_16Gb_4hi": {"density": 16384, "dq": 32, "channel_width": 32, "pseudochannel": 2, "sid": 1, "bankgroup": 4, "bank": 4, "row": 1<<14, "column": (1<<5) << 3},
     "HBM3_8Gb_8hi":  {"density": 8192, "dq": 32, "channel_width": 32, "pseudochannel": 2, "sid": 2, "bankgroup": 4, "bank": 4, "row": 1<<13, "column": (1<<5) << 3},  # HBM CA already takes BL into account
     # die density = 16 Gb, channel density = 8 Gb
     "HBM3_16Gb_8hi": {"density": 16384, "dq": 32, "channel_width": 32, "pseudochannel": 2, "sid": 2, "bankgroup": 4, "bank": 4, "row": 1<<14, "column": (1<<5) << 3},  # HBM CA already takes BL into account


### PR DESCRIPTION
Low-end stacks for low-power / embedded HBM3 workloads — small form factor variants (e.g. NVIDIA Jetson Thor-class, automotive HBM3) where 4-Hi is the standard package height instead of the 8-Hi / 12-Hi / 16-Hi datacenter stacks.

Adds:

| preset | sid | per-pkg |
|---|---|---|
| `HBM3_8Gb_4hi` | 1 | 4 GB |
| `HBM3_16Gb_4hi` | 1 | 8 GB |

Same shape as the existing 8-Hi / 16-Hi entries — only `sid` differs. Slots cleanly into the 4 / 8 / 12 / 16-Hi sequence.