### PR TITLE
feat(hbm3): add HBM3_7600Mbps preset

### DIFF
--- a/python/ramulator/dram/hbm3.py
+++ b/python/ramulator/dram/hbm3.py
@@ -224,6 +224,19 @@ HBM3.org_presets = {
 # Timing presets — CK cycles. Non-refresh timing values are supplied directly
 # here; refresh-related values may be supplied here or resolved below.
 HBM3.timing_presets = {
+    # HBM3_7600Mbps — 1.1875x of HBM3_6400. Common low-bin HBM3
+    # rate seen on early Samsung HBM3 samples that didn't clear
+    # the full 8.0 Gbps validation gate.
+    "HBM3_7600Mbps": {
+        "rate": 7600, "nBL": 2, "nCL": 24, "nRCDRD": 37, "nRCDWR": 18,
+        "nRP": 31, "nRAS": 53, "nRC": 86, "nWR": 39, "nRTP": 11, "nCWL": 12,
+        "nCCDS": 2, "nCCDL": 5, "nCCDR": 4,
+        "nRRDS": 5, "nRRDL": 6, "nFAW": 29,
+        "nWTRS": 8, "nWTRL": 12, "nRTW": 24,
+        "nRFCpb": 380, "nRREFD": 8, "nREFI": 7410,
+        "nPPD": 2,
+        "tCK_ps": 526,
+    },
     "HBM3_6400Mbps": {
         "rate": 6400, "nBL": 2, "nCL": 20, "nRCDRD": 31, "nRCDWR": 15,
         "nRP": 26, "nRAS": 45, "nRC": 72, "nWR": 33, "nRTP": 9, "nCWL": 10,


### PR DESCRIPTION
1.1875x of HBM3_6400Mbps. Common low-bin HBM3 rate seen on early Samsung HBM3 samples that didn't clear the full 8.0 Gbps validation gate.