### PR TITLE
feat(hbm3): add HBM3_8Gb_16hi org preset

### DIFF
--- a/python/ramulator/dram/hbm3.py
+++ b/python/ramulator/dram/hbm3.py
@@ -213,6 +213,9 @@ HBM3.org_presets = {
     "HBM3_4Gb":  {"density": 4096, "dq": 32, "channel_width": 32, "pseudochannel": 2, "sid": 1, "bankgroup": 4, "bank": 4, "row": 1<<14, "column": (1<<5) << 3},  # HBM CA already takes BL into account
     # die density = 8 Gb, channel density = 4 Gb
     "HBM3_8Gb_8hi":  {"density": 8192, "dq": 32, "channel_width": 32, "pseudochannel": 2, "sid": 2, "bankgroup": 4, "bank": 4, "row": 1<<13, "column": (1<<5) << 3},  # HBM CA already takes BL into account
+    # HBM3_8Gb_16hi: 8 Gb base die at 16-Hi stack (sid=4) — matches
+    # early HBM3 datacenter prototypes paired with sub-A100 accelerators.
+    "HBM3_8Gb_16hi": {"density": 8192, "dq": 32, "channel_width": 32, "pseudochannel": 2, "sid": 4, "bankgroup": 4, "bank": 4, "row": 1<<13, "column": (1<<5) << 3},
     # die density = 16 Gb, channel density = 8 Gb
     "HBM3_16Gb_8hi": {"density": 16384, "dq": 32, "channel_width": 32, "pseudochannel": 2, "sid": 2, "bankgroup": 4, "bank": 4, "row": 1<<14, "column": (1<<5) << 3},  # HBM CA already takes BL into account
     # die density = 32 Gb, channel density = 16 Gb


### PR DESCRIPTION
8 Gb base die at 16-Hi stack (sid=4) — matches early HBM3 datacenter prototypes paired with sub-A100 accelerators.