### PR TITLE
feat(hbm4): add HBM4_16Gb_4Hi/8Hi org presets

### DIFF
--- a/python/ramulator/dram/hbm4.py
+++ b/python/ramulator/dram/hbm4.py
@@ -173,6 +173,11 @@ class HBM4(DRAMStandard):
 HBM4.org_presets = {
     "HBM4_32Gb_4Hi":  {"density": 32768, "dq": 32, "channel_width": 32, "pseudochannel": 2, "sid": 1, "bankgroup": 2, "bank": 8, "row": 1<<14, "column": (1<<5) << 3},  # HBM CA already takes BL into account
     "HBM4_32Gb_8Hi":  {"density": 32768, "dq": 32, "channel_width": 32, "pseudochannel": 2, "sid": 2, "bankgroup": 2, "bank": 8, "row": 1<<14, "column": (1<<5) << 3},  # HBM CA already takes BL into account
+    # HBM4_16Gb dies — smaller alternative to the 32 Gb base, useful
+    # for low-density HBM4 modeling (e.g. embedded HBM4 accelerator
+    # prototypes). Half the row count, same bank organization.
+    "HBM4_16Gb_4Hi":  {"density": 16384, "dq": 32, "channel_width": 32, "pseudochannel": 2, "sid": 1, "bankgroup": 2, "bank": 8, "row": 1<<13, "column": (1<<5) << 3},
+    "HBM4_16Gb_8Hi":  {"density": 16384, "dq": 32, "channel_width": 32, "pseudochannel": 2, "sid": 2, "bankgroup": 2, "bank": 8, "row": 1<<13, "column": (1<<5) << 3},
     "HBM4_32Gb_16Hi": {"density": 32768, "dq": 32, "channel_width": 32, "pseudochannel": 2, "sid": 4, "bankgroup": 2, "bank": 8, "row": 1<<14, "column": (1<<5) << 3},  # HBM CA already takes BL into account
 }
 


### PR DESCRIPTION
Smaller alternative to the 32 Gb base — useful for low-density HBM4 modeling (embedded HBM4 accelerator prototypes). Half the row count, same bank organization.