### PR TITLE
feat(hbm4): add HBM4_8Gb_4Hi/8Hi entry-density org presets

### DIFF
--- a/python/ramulator/dram/hbm4.py
+++ b/python/ramulator/dram/hbm4.py
@@ -171,6 +171,10 @@ class HBM4(DRAMStandard):
 
 
 HBM4.org_presets = {
+    # HBM4_8Gb dies — entry-density modeling for resource-constrained
+    # HBM4 prototypes.
+    "HBM4_8Gb_4Hi":  {"density": 8192, "dq": 32, "channel_width": 32, "pseudochannel": 2, "sid": 1, "bankgroup": 2, "bank": 8, "row": 1<<12, "column": (1<<5) << 3},
+    "HBM4_8Gb_8Hi":  {"density": 8192, "dq": 32, "channel_width": 32, "pseudochannel": 2, "sid": 2, "bankgroup": 2, "bank": 8, "row": 1<<12, "column": (1<<5) << 3},
     "HBM4_32Gb_4Hi":  {"density": 32768, "dq": 32, "channel_width": 32, "pseudochannel": 2, "sid": 1, "bankgroup": 2, "bank": 8, "row": 1<<14, "column": (1<<5) << 3},  # HBM CA already takes BL into account
     "HBM4_32Gb_8Hi":  {"density": 32768, "dq": 32, "channel_width": 32, "pseudochannel": 2, "sid": 2, "bankgroup": 2, "bank": 8, "row": 1<<14, "column": (1<<5) << 3},  # HBM CA already takes BL into account
     "HBM4_32Gb_16Hi": {"density": 32768, "dq": 32, "channel_width": 32, "pseudochannel": 2, "sid": 4, "bankgroup": 2, "bank": 8, "row": 1<<14, "column": (1<<5) << 3},  # HBM CA already takes BL into account


### PR DESCRIPTION
Entry-density modeling for resource-constrained HBM4 prototypes. Quarter row count of the 32 Gb base.