### PR TITLE
feat(lpddr5): add LPDDR5_2Gb_x16 entry-density org preset

### DIFF
--- a/python/ramulator/dram/lpddr5.py
+++ b/python/ramulator/dram/lpddr5.py
@@ -177,6 +177,9 @@ class LPDDR5(DRAMStandard):
 LPDDR5.org_presets = {
     "LPDDR5_8Gb_x16":  {"density": 8192,  "dq": 16, "channel_width": 16, "rank": 1, "bankgroup": 4, "bank": 4, "row": 1<<15, "column": 1<<10},
     "LPDDR5_16Gb_x16": {"density": 16384, "dq": 16, "channel_width": 16, "rank": 1, "bankgroup": 4, "bank": 4, "row": 1<<16, "column": 1<<10},
+    # LPDDR5_2Gb_x16 — smallest LPDDR5 die for embedded / IoT
+    # validation silicon.
+    "LPDDR5_2Gb_x16":  {"density": 2048, "dq": 16, "channel_width": 16, "rank": 1, "bankgroup": 4, "bank": 4, "row": 1<<13, "column": 1<<10},
 }
 
 # Primary timings only — secondary timings resolved by resolve_secondary_timings().


### PR DESCRIPTION
Smallest LPDDR5 die for embedded / IoT validation silicon. Quarter row count of the existing 8 Gb base.