### PR TITLE
feat(hbm3): add HBM3_4Gb_8hi org preset

### DIFF
--- a/python/ramulator/dram/hbm3.py
+++ b/python/ramulator/dram/hbm3.py
@@ -211,6 +211,9 @@ class HBM3(DRAMStandard):
 HBM3.org_presets = {
     # die density = 4 Gb, channel density = 4 Gb
     "HBM3_4Gb":  {"density": 4096, "dq": 32, "channel_width": 32, "pseudochannel": 2, "sid": 1, "bankgroup": 4, "bank": 4, "row": 1<<14, "column": (1<<5) << 3},  # HBM CA already takes BL into account
+    # HBM3_4Gb_8hi — 4 Gb die at 8-Hi stack (4 GB package).
+    # Low-end HBM3 modeling for prototype silicon.
+    "HBM3_4Gb_8hi": {"density": 4096, "dq": 32, "channel_width": 32, "pseudochannel": 2, "sid": 2, "bankgroup": 4, "bank": 4, "row": 1<<14, "column": (1<<5) << 3},
     # die density = 8 Gb, channel density = 4 Gb
     "HBM3_8Gb_8hi":  {"density": 8192, "dq": 32, "channel_width": 32, "pseudochannel": 2, "sid": 2, "bankgroup": 4, "bank": 4, "row": 1<<13, "column": (1<<5) << 3},  # HBM CA already takes BL into account
     # die density = 16 Gb, channel density = 8 Gb


### PR DESCRIPTION
4 Gb die at 8-Hi stack (4 GB package). Low-end HBM3 modeling for prototype silicon.