### PR TITLE
feat(hbm4): add HBM4_10400Mbps intermediate bin

### DIFF
--- a/python/ramulator/dram/hbm4.py
+++ b/python/ramulator/dram/hbm4.py
@@ -197,4 +197,16 @@ HBM4.timing_presets = {
         "nRFCpb": 1120, "nRREFD": 8,
         "tCK_ps": 250,
     },
+    # HBM4 10.4 Gbps — intermediate bin scaled 1.3× off the 8 Gbps base.
+    # Plausible HBM4 second-wave production grade.
+    "HBM4_10400Mbps": {
+        "rate": 10400, "nBL": 2, "nCL": 26, "nCWL": 13,
+        "nRC": 117, "nRAS": 75, "nRP": 43, "nRCDRD": 51, "nRCDWR": 25,
+        "nRRDL": 10, "nRRDS": 7, "nFAW": 39, "nRTP": 16, "nWR": 55,
+        "nCCDL": 4, "nCCDS": 2, "nCCDR": 2,
+        "nWTRL": 17, "nWTRS": 12, "nRTW": 33,
+        "nPPD": 2,
+        "nRFCpb": 728, "nRREFD": 8,
+        "tCK_ps": 384,
+    },
 }


### PR DESCRIPTION
## Summary
Adds HBM4_10400Mbps — intermediate timing preset between the 8 Gbps JEDEC base and the 16 Gbps top bin.

## Motivation
Timing parameters scaled 1.3x from the 8 Gbps base; tCK_ps follows. Plausible HBM4 second-wave production grade — useful for early HBM4 SOC integration studies.

## Verification
Preset loads cleanly.