### PR TITLE
feat(lpddr5): add LPDDR5_4267 lower-tier bin

### DIFF
--- a/python/ramulator/dram/lpddr5.py
+++ b/python/ramulator/dram/lpddr5.py
@@ -190,4 +190,14 @@ LPDDR5.timing_presets = {
         "nWTRS": 5, "nWTRL": 10, "nWCKPST": 1, "nCAS": 0,
         "nAAD": 8, "nCS": 2, "tCK_ps": 1250,
     },
+    # LPDDR5-4267 (tCK = 1875 ps, CK = 533 MHz) — lower-tier bin used
+    # in mid-range smartphone / IoT applications targeting battery
+    # life over peak bandwidth.
+    "LPDDR5_4267": {
+        "rate": 4267, "nBL": 2, "nCL": 12, "nRCD": 10, "nRP": 10, "nRPab": 12,
+        "nRAS": 23, "nRC": 33, "nWR": 19, "nRTP": 6, "nCWL": 6, "nPPD": 2,
+        "nCCDS": 2, "nCCDL": 4, "nCCDS_WR": 2, "nCCDL_WR": 4,
+        "nWTRS": 4, "nWTRL": 7, "nWCKPST": 1, "nCAS": 0,
+        "nAAD": 8, "nCS": 2, "tCK_ps": 1875,
+    },
 }


### PR DESCRIPTION
## Summary
Adds LPDDR5_4267 — lower-tier bin for mid-range mobile / IoT use cases.

## Motivation
LPDDR5 bins span 4267 Mbps (entry tier) up to 10667 Mbps (LPDDR5X). The repo only had 6400/7200/9600/10667; this fills the bottom of the ladder for mid-range mobile and IoT power-constrained modeling.

## Verification
Preset loads cleanly.