### PR TITLE
feat(hbm2): add HBM2_16Gb density preset

### DIFF
--- a/python/ramulator/dram/hbm2.py
+++ b/python/ramulator/dram/hbm2.py
@@ -190,6 +190,9 @@ HBM2.org_presets = {
     "HBM2_2Gb":  {"density": 2048, "dq": 64, "channel_width": 64, "pseudochannel": 2, "bankgroup": 4, "bank": 4, "row": 1<<14, "column": (1<<5) << 2},  # HBM CA already takes BL into account
     "HBM2_4Gb":  {"density": 4096, "dq": 64, "channel_width": 64, "pseudochannel": 2, "bankgroup": 4, "bank": 4, "row": 1<<15, "column": (1<<5) << 2},  # HBM CA already takes BL into account
     "HBM2_8Gb":  {"density": 8192, "dq": 64, "channel_width": 64, "pseudochannel": 2, "bankgroup": 4, "bank": 4, "row": 1<<16, "column": (1<<5) << 2},  # HBM CA already takes BL into account
+    # HBM2E 16 Gb die — used by Samsung Flashbolt and SK hynix HBM2E.
+    # Per-channel density doubles vs HBM2_8Gb; falls into the >8 Gb tRFC bucket.
+    "HBM2_16Gb": {"density": 16384, "dq": 64, "channel_width": 64, "pseudochannel": 2, "bankgroup": 4, "bank": 4, "row": 1<<17, "column": (1<<5) << 2},  # HBM CA already takes BL into account
 }
 
 # Timing presets — primary timings only.


### PR DESCRIPTION
## Summary
Adds HBM2_16Gb — 16 Gb HBM2E die used by Samsung Flashbolt and SK hynix HBM2E.

## Motivation
Per-channel density doubles vs HBM2_8Gb. The existing _resolve_nRFC() table already has an else: 450 ns bucket for densities > 8 Gb, so the preset works without modifying the table.

## Verification
Preset loads cleanly.